### PR TITLE
fix: race condition causes multiple songs to play at the same time

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -457,6 +457,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.0.12"
+  mutex:
+    dependency: "direct main"
+    description:
+      name: mutex
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   nested:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   uuid: ^3.0.4
   golden_toolkit: ^0.9.0
   fake_async: ^1.2.0
+  mutex: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Thank you for your work with Koel, I'm becoming a big fan of it :-)

### The problem

Doing multiple taps at the same time (e.g. using two fingers to tap on two songs at the same time) causes both audio sources to play at the same time. You can only control (pause/stop/etc.) one of them, and the other keeps playing without the user being able to stop it.

### Proposed fix

I wrapped the `AudioProvider.play()` function inside a mutex so the multiple taps are treated separately.