### PR TITLE
Add Support for Downloading All Songs in an Album or Playlist

### DIFF
--- a/lib/providers/download_provider.dart
+++ b/lib/providers/download_provider.dart
@@ -24,12 +24,15 @@ class DownloadProvider with StreamSubscriber {
   final _downloadsCleared = StreamController<bool>.broadcast();
   final _downloadRemoved = StreamController<Song>.broadcast();
   final _songDownloaded = StreamController<Download>.broadcast();
+  final _songDownloadStarted = StreamController<Song>.broadcast();
 
   Stream<bool> get downloadsClearedStream => _downloadsCleared.stream;
 
   Stream<Song> get downloadRemovedStream => _downloadRemoved.stream;
 
   Stream<Download> get songDownloadedStream => _songDownloaded.stream;
+
+  Stream<Song> get downloadStartedStream => _songDownloadStarted.stream;
 
   static const serializedSongContainer = 'Downloads';
   static const downloadCacheKey = 'koel.downloaded.songs';
@@ -79,6 +82,8 @@ class DownloadProvider with StreamSubscriber {
   get serializedSongKey => '${preferences.host}.${preferences.userEmail}.songs';
 
   Future<void> download({required Song song}) async {
+    _songDownloadStarted.add(song);
+
     final file = await _downloadManager.downloadFile(
       song.sourceUrl,
       key: song.cacheKey,

--- a/lib/ui/screens/album_details.dart
+++ b/lib/ui/screens/album_details.dart
@@ -70,6 +70,7 @@ class _AlbumDetailsScreenState extends State<AlbumDetailsScreen> {
                     AppBar(
                       headingText: album.name,
                       actions: [
+                        SongListCacheIcon(songs: songs),
                         SortButton(
                           fields: ['track', 'title', 'created_at'],
                           currentField: sortConfig.field,

--- a/lib/ui/screens/playlist_details.dart
+++ b/lib/ui/screens/playlist_details.dart
@@ -76,6 +76,7 @@ class _PlaylistDetailsScreen extends State<PlaylistDetailsScreen> {
                     headingText: playlist.name,
                     coverImage: _cover,
                     actions: [
+                      SongListCacheIcon(songs: songs),
                       SortButton(
                         fields: ['title', 'artist_name', 'created_at'],
                         currentField: sortConfig.field,

--- a/lib/ui/widgets/widgets.dart
+++ b/lib/ui/widgets/widgets.dart
@@ -29,3 +29,4 @@ export 'song_row.dart';
 export 'song_thumbnail.dart';
 export 'spinner.dart';
 export 'typography.dart';
+export 'song_list_cache_icon.dart';


### PR DESCRIPTION
First off, I want to thank all contributors of Koel. The website/server and app both look amazing and work really well. Now to the pull request:

These changes address issue #63 for downloading all songs of an album (or playlist). Basically, I copied the SongCacheIcon to SongListCacheIcon which expects a list of songs instead of a single song. I modified the code slightly to update its download/downloading state based on all songs in the list. Furthermore, the download() method downloads up to three songs in parallel. To inform each song about its downloading state, which can now change from outside (i.e. the album or playlist) I also added a new StreamController to broadcast when a download has been initiated.

If there are any further changes or tweaks you'd like me to make, please don't hesitate to let me know.

![Screenshot_1683730941(1)](https://github.com/koel/player/assets/7702320/32456339-7f11-495f-8df7-9c17791d65dd)
![Screenshot_1683730899(1)](https://github.com/koel/player/assets/7702320/c47a2952-1e7e-4adc-83aa-890123af7742)
