### PR TITLE
Added initial notes for getting started with development.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Koel Player is built on Flutter and Dart. If you're new to Flutter, here are a f
 For more help, visit the [online documentation](https://flutter.dev/docs), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
 
+Koel uses flutter version 3.7.12, which can be obtained by cloning the [Flutter GitHub](https://github.com/flutter/flutter) and using `git checkout 3.7.12`. The flutter/bin folder will have the flutter binaries available. 
+
 ## License
 
 MIT.


### PR DESCRIPTION
Partially addresses #61 and #75 by at least confirming the version of flutter that will build (3.3 won't and anything newer also seems to not build)

I can add a full getting started guide on Linux if that would be helpful. Feel free to reject or add requirements. This was mostly so that I could take a stab at #41 later. 