### PR TITLE
feat: add theme switcher to toggle between colorful and black themes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -92,7 +92,7 @@ Future<void> main() async {
   runApp(
     MultiProvider(
       providers: _providers,
-      child: const App(),
+      child: App(),
     ),
   );
 }

--- a/lib/ui/app.dart
+++ b/lib/ui/app.dart
@@ -3,12 +3,20 @@ import 'package:app/router.dart';
 import 'package:app/ui/screens/screens.dart';
 import 'package:app/ui/theme_data.dart';
 import 'package:app/ui/widgets/widgets.dart';
+import 'package:app/utils/preferences.dart' as preferences;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-class App extends StatelessWidget {
-  const App({Key? key}) : super(key: key);
+final GlobalKey<_AppState> appKey = GlobalKey<_AppState>();
 
+class App extends StatefulWidget {
+  App({Key? key}) : super(key: appKey);
+
+  @override
+  State<App> createState() => _AppState();
+}
+
+class _AppState extends State<App> {
   @override
   Widget build(BuildContext context) {
     SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
@@ -25,5 +33,9 @@ class App extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  void refreshTheme() {
+    setState(() {});
   }
 }

--- a/lib/ui/widgets/gradient_decorated_container.dart
+++ b/lib/ui/widgets/gradient_decorated_container.dart
@@ -1,3 +1,4 @@
+import 'package:app/utils/preferences.dart' as preferences;
 import 'package:flutter/material.dart';
 
 class GradientDecoratedContainer extends StatelessWidget {
@@ -10,11 +11,14 @@ class GradientDecoratedContainer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isDark = preferences.isDarkTheme;
+
     return Container(
       child: child,
       padding: padding,
-      decoration: const BoxDecoration(
-        image: DecorationImage(
+      decoration: BoxDecoration(
+        color: isDark ? const Color(0xFF000000) : null,
+        image: isDark ? null : const DecorationImage(
           image: AssetImage('assets/images/background.webp'),
           fit: BoxFit.cover,
           alignment: Alignment.bottomLeft,

--- a/lib/ui/widgets/profile_avatar.dart
+++ b/lib/ui/widgets/profile_avatar.dart
@@ -1,18 +1,26 @@
 import 'package:app/main.dart';
 import 'package:app/providers/providers.dart';
+import 'package:app/ui/app.dart';
 import 'package:app/ui/screens/screens.dart';
+import 'package:app/utils/preferences.dart' as preferences;
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 enum ProfileAvatarMenuItems {
+  toggleTheme,
   clearDownloads,
   logout,
 }
 
-class ProfileAvatar extends StatelessWidget {
+class ProfileAvatar extends StatefulWidget {
   const ProfileAvatar({Key? key}) : super(key: key);
 
+  @override
+  State<ProfileAvatar> createState() => _ProfileAvatarState();
+}
+
+class _ProfileAvatarState extends State<ProfileAvatar> {
   void logout(BuildContext context) {
     showCupertinoDialog(
       context: context,
@@ -49,6 +57,12 @@ class ProfileAvatar extends StatelessWidget {
     return PopupMenuButton<ProfileAvatarMenuItems>(
       onSelected: (item) {
         switch (item) {
+          case ProfileAvatarMenuItems.toggleTheme:
+            setState(() {
+              preferences.isDarkTheme = !preferences.isDarkTheme;
+              appKey.currentState?.refreshTheme();
+            });
+            break;
           case ProfileAvatarMenuItems.clearDownloads:
             downloads.clear();
             break;
@@ -60,6 +74,24 @@ class ProfileAvatar extends StatelessWidget {
       child: const Icon(CupertinoIcons.person_alt_circle, size: 24),
       offset: const Offset(0, 32),
       itemBuilder: (_) => [
+        PopupMenuItem(
+          value: ProfileAvatarMenuItems.toggleTheme,
+          child: Row(
+            children: [
+              Icon(
+                preferences.isDarkTheme
+                    ? CupertinoIcons.sun_max_fill
+                    : CupertinoIcons.moon_fill,
+                size: 18,
+              ),
+              const SizedBox(width: 12),
+              Text(preferences.isDarkTheme
+                  ? 'Switch to Colorful'
+                  : 'Switch to Black'),
+            ],
+          ),
+        ),
+        const PopupMenuDivider(height: .5),
         const PopupMenuItem(
           value: ProfileAvatarMenuItems.clearDownloads,
           child: Text('Clear downloads'),

--- a/lib/utils/preferences.dart
+++ b/lib/utils/preferences.dart
@@ -49,3 +49,7 @@ AudioServiceRepeatMode get repeatMode {
 set volume(double volume) => _set('volume', volume);
 
 double get volume => _get<double>('volume') ?? 0.7;
+
+set isDarkTheme(bool isDark) => _set('isDarkTheme', isDark);
+
+bool get isDarkTheme => _get<bool>('isDarkTheme') ?? false;


### PR DESCRIPTION
Add a theme toggle option in the user profile menu to switch between the original colorful gradient theme and a pure black theme.

Features:
- Theme switcher in profile menu (Home screen top-right corner)
- Toggle between colorful (purple/red gradient) and black (#000000) background
- Visual icons: moon for black theme, sun for colorful theme
- Persists theme preference across app restarts
- Instant theme refresh when toggled

The theme switcher appears as the first item in the profile menu, above 'Clear downloads' and 'Log out' options.