### PR TITLE
fix: when sorting by track, disc number is not considered

### DIFF
--- a/lib/models/song.dart
+++ b/lib/models/song.dart
@@ -269,17 +269,19 @@ class Song extends Playable<Song> {
 
   @override
   Comparable valueToCompare(PlayableSortConfig config) {
+    final discTrack = '${disc.toString().padLeft(6, '0')}${track.toString().padLeft(6, '0')}';
+
     switch (config.field) {
       case 'title':
         return title;
       case 'album_name':
-        return '${albumName}${albumId}${track}';
+        return '${albumName}${albumId}${discTrack}';
       case 'artist_name':
-        return '${artistName}${albumName}${track}';
+        return '${artistName}${albumName}${discTrack}';
       case 'created_at':
         return createdAt;
       case 'track':
-        return track;
+        return discTrack;
       default:
         return '';
     }


### PR DESCRIPTION
When sorting songs by "track", we currently ignore the disc number. This means if there's an album with multiple discs, it will be sorted as:

```
disc1 track1
disc2 track1
disc1 track2
disc2 track2
disc1 track3
disc2 track3
```

Instead it makes more sense to sort as:

```
disc1 track1
disc1 track2
disc1 track3
disc2 track1
disc2 track2
disc2 track3
```

The proposed change adds the disc number before the track number (and also prefix track numbers with zeros to ensure alphabetical order is consistent with numerical order)

I haven't been able to setup the project to build locally, so this needs a test still.

Thanks for making this great project!