### PR TITLE
fix: autofillHints in login screen

### DIFF
--- a/lib/ui/screens/login.dart
+++ b/lib/ui/screens/login.dart
@@ -170,6 +170,7 @@ class _LoginScreenState extends State<LoginScreen> with StreamSubscriber {
                     TextFormField(
                       keyboardType: TextInputType.url,
                       autocorrect: false,
+                      autofillHints: null,
                       onChanged: (value) => _host = value,
                       onSaved: (value) => _host = value ?? '',
                       decoration: InputDecoration(
@@ -182,6 +183,7 @@ class _LoginScreenState extends State<LoginScreen> with StreamSubscriber {
                     TextFormField(
                       keyboardType: TextInputType.emailAddress,
                       autocorrect: false,
+                      autofillHints: [AutofillHints.email],
                       onChanged: (value) => _email = value,
                       onSaved: (value) => _email = value ?? '',
                       decoration: InputDecoration(
@@ -194,6 +196,7 @@ class _LoginScreenState extends State<LoginScreen> with StreamSubscriber {
                     TextFormField(
                       obscureText: !_showPassword,
                       keyboardType: TextInputType.visiblePassword,
+                      autofillHints: [AutofillHints.password],
                       onChanged: (value) => _password = value,
                       onSaved: (value) => _password = value ?? '',
                       decoration: InputDecoration(


### PR DESCRIPTION
This adds autofill hints to the login screen's email and password inputs.

It explicitly sets autofill hint for `url` to `null` to disable autofill on that field.

Tested on Android:

<img width="270" height="600" alt="Screenshot_20260319-225237" src="https://github.com/user-attachments/assets/9fdf5ad1-2293-4781-a8e7-a2e6f011a225" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced autofill support on the login form. Email and password fields now work seamlessly with your device's native autofill functionality, streamlining the login experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->