### PR TITLE
Replace favorite heart icons with stars

### DIFF
--- a/lib/ui/screens/favorites.dart
+++ b/lib/ui/screens/favorites.dart
@@ -65,7 +65,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
               const Icon(
-                CupertinoIcons.heart,
+                CupertinoIcons.star,
                 size: 56.0,
                 color: Colors.grey,
               ),
@@ -85,7 +85,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
                       child: Padding(
                         padding: EdgeInsets.symmetric(horizontal: 5.0),
                         child: Icon(
-                          CupertinoIcons.heart_solid,
+                          CupertinoIcons.star_fill,
                           size: 16.0,
                         ),
                       ),
@@ -163,7 +163,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
                             listContext: PlayableListContext.favorites,
                             rightPadding: showScrollbar ? alphabetScrollbarWidth * 0.75 : 0,
                             onDismissed: provider.unlike,
-                            dismissIcon: const Icon(CupertinoIcons.heart_slash),
+                            dismissIcon: const Icon(CupertinoIcons.star_slash),
                           ),
                           const BottomSpace(),
                         ],

--- a/lib/ui/screens/library.dart
+++ b/lib/ui/screens/library.dart
@@ -30,7 +30,7 @@ class LibraryScreen extends StatelessWidget {
           ),
         ),
         LibraryMenuItem(
-          icon: CupertinoIcons.heart_fill,
+          icon: CupertinoIcons.star_fill,
           label: 'Favorites',
           onTap: () => Navigator.of(context).push(
             CupertinoPageRoute(builder: (_) => const FavoritesScreen()),

--- a/lib/ui/screens/now_playing.dart
+++ b/lib/ui/screens/now_playing.dart
@@ -239,7 +239,7 @@ class _NowPlayingScreenState extends State<NowPlayingScreen>
                                               ? CupertinoIcons.star_fill
                                               : CupertinoIcons.star,
                                           color: playable.liked
-                                              ? Colors.amber
+                                              ? Colors.white
                                               : bottomIconColor,
                                         ),
                                       ),

--- a/lib/ui/screens/now_playing.dart
+++ b/lib/ui/screens/now_playing.dart
@@ -236,10 +236,10 @@ class _NowPlayingScreenState extends State<NowPlayingScreen>
                                         },
                                         icon: Icon(
                                           playable.liked
-                                              ? CupertinoIcons.heart_fill
-                                              : CupertinoIcons.heart,
+                                              ? CupertinoIcons.star_fill
+                                              : CupertinoIcons.star,
                                           color: playable.liked
-                                              ? Colors.red
+                                              ? Colors.amber
                                               : bottomIconColor,
                                         ),
                                       ),

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -151,7 +151,7 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                     playable.liked
                         ? CupertinoIcons.star_fill
                         : CupertinoIcons.star,
-                    color: playable.liked ? Colors.amber : Colors.white30,
+                    color: Colors.white30,
                   ),
                   onTap: () {
                     showOverlay(

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -149,9 +149,9 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                       : 'Mark as Favorite',
                   icon: Icon(
                     playable.liked
-                        ? CupertinoIcons.heart_fill
-                        : CupertinoIcons.heart,
-                    color: Colors.white30,
+                        ? CupertinoIcons.star_fill
+                        : CupertinoIcons.star,
+                    color: playable.liked ? Colors.amber : Colors.white30,
                   ),
                   onTap: () {
                     showOverlay(
@@ -161,8 +161,8 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                           ? 'Removed from Favorites.'
                           : 'Added to Favorites.',
                       icon: playable.liked
-                          ? CupertinoIcons.heart_slash
-                          : CupertinoIcons.heart_fill,
+                          ? CupertinoIcons.star_slash
+                          : CupertinoIcons.star_fill,
                     );
                     favoriteProvider.toggleOne(playable: playable);
                   },


### PR DESCRIPTION
## Summary
- Replace all heart icons (`heart`, `heart_fill`, `heart_solid`, `heart_slash`) with star equivalents (`star`, `star_fill`, `star_slash`)
- Applied across: Now Playing screen, Favorites screen, Library menu, action sheet

## Test plan
- [ ] Open Now Playing — verify star icon, golden when liked
- [ ] Open action sheet on a song — verify star icon in favorite toggle
- [ ] Toggle favorite — verify overlay shows star icons
- [ ] Open Library — verify Favorites menu item has star icon
- [ ] Open Favorites screen (empty) — verify star icon in empty state
- [ ] Swipe to unfavorite — verify star_slash icon
- [ ] Run `flutter test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Replaced heart icons with star icons across favorites, library, now-playing, action sheets, and swipe actions
  * Updated liked-item highlight color from red to white, preserving existing behavior and labels
<!-- end of auto-generated comment: release notes by coderabbit.ai -->