### PR TITLE
Add radio stations to search results

### DIFF
--- a/lib/providers/search_provider.dart
+++ b/lib/providers/search_provider.dart
@@ -9,12 +9,14 @@ class SearchResult {
   var artists = <Artist>[];
   var albums = <Album>[];
   var podcasts = <Podcast>[];
+  var radioStations = <RadioStation>[];
 
   SearchResult({
     this.playables = const [],
     this.artists = const [],
     this.albums = const [],
     this.podcasts = const [],
+    this.radioStations = const [],
   });
 }
 
@@ -50,6 +52,12 @@ class SearchProvider with ChangeNotifier {
         ? []
         : res['podcasts'].map<Podcast>((j) => Podcast.fromJson(j)).toList();
 
+    final List<RadioStation> radioStations = res['radio_stations'] == null
+        ? []
+        : res['radio_stations']
+            .map<RadioStation>((j) => RadioStation.fromJson(j))
+            .toList();
+
     return AppState.set(
       cacheKey,
       SearchResult(
@@ -57,6 +65,7 @@ class SearchProvider with ChangeNotifier {
         artists: artists,
         albums: albums,
         podcasts: podcasts,
+        radioStations: radioStations,
       ),
     );
   }

--- a/lib/ui/screens/search.dart
+++ b/lib/ui/screens/search.dart
@@ -24,6 +24,7 @@ class _SearchScreenState extends State<SearchScreen> {
   var _artists = <Artist>[];
   var _albums = <Album>[];
   var _podcasts = <Podcast>[];
+  var _radioStations = <RadioStation>[];
 
   late final SearchProvider searchProvider;
   final _controller = TextEditingController(text: '');
@@ -55,6 +56,7 @@ class _SearchScreenState extends State<SearchScreen> {
           _albums = result.albums;
           _artists = result.artists;
           _podcasts = result.podcasts;
+          _radioStations = result.radioStations;
         });
       });
 
@@ -177,6 +179,22 @@ class _SearchScreenState extends State<SearchScreen> {
                               ),
                             ),
                         ],
+                        const SizedBox(height: 32),
+                        Padding(
+                          padding: const EdgeInsets.only(
+                            left: AppDimensions.hPadding,
+                          ),
+                          child: const Heading5(text: 'Radio Stations'),
+                        ),
+                        if (_radioStations.isEmpty)
+                          noResults
+                        else
+                          HorizontalCardScroller(
+                            cards: _radioStations.map(
+                              (station) =>
+                                  RadioStationCard(station: station),
+                            ),
+                          ),
                         const BottomSpace(asSliver: false),
                       ],
                     ),

--- a/lib/ui/widgets/radio_station_card.dart
+++ b/lib/ui/widgets/radio_station_card.dart
@@ -1,0 +1,98 @@
+import 'package:app/models/models.dart';
+import 'package:app/providers/providers.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:figma_squircle/figma_squircle.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class RadioStationCard extends StatefulWidget {
+  final RadioStation station;
+  final VoidCallback? onTap;
+
+  const RadioStationCard({Key? key, required this.station, this.onTap})
+      : super(key: key);
+
+  @override
+  _RadioStationCardState createState() => _RadioStationCardState();
+}
+
+class _RadioStationCardState extends State<RadioStationCard> {
+  var _opacity = 1.0;
+  final _cardWidth = 144.0;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTapDown: (_) => setState(() => _opacity = 0.4),
+      onTapUp: (_) => setState(() => _opacity = 1.0),
+      onTapCancel: () => setState(() => _opacity = 1.0),
+      onTap: widget.onTap ??
+          () => context.read<RadioPlayerProvider>().play(widget.station),
+      behavior: HitTestBehavior.opaque,
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 100),
+        opacity: _opacity,
+        child: Column(
+          children: <Widget>[
+            ClipSmoothRect(
+              radius: SmoothBorderRadius(
+                cornerRadius: 16,
+                cornerSmoothing: .8,
+              ),
+              child: SizedBox(
+                width: _cardWidth,
+                height: _cardWidth,
+                child: widget.station.logo != null
+                    ? CachedNetworkImage(
+                        imageUrl: widget.station.logo!,
+                        width: _cardWidth,
+                        height: _cardWidth,
+                        fit: BoxFit.cover,
+                        errorWidget: (_, __, ___) => _defaultIcon(),
+                      )
+                    : _defaultIcon(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: _cardWidth,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    widget.station.name,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (widget.station.description != null &&
+                      widget.station.description!.isNotEmpty) ...[
+                    const SizedBox(height: 6),
+                    Text(
+                      widget.station.description!,
+                      style: const TextStyle(color: Colors.white54),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _defaultIcon() {
+    return Container(
+      width: _cardWidth,
+      height: _cardWidth,
+      color: Colors.white12,
+      child: const Icon(
+        CupertinoIcons.antenna_radiowaves_left_right,
+        size: 48,
+        color: Colors.white54,
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/radio_station_card.dart
+++ b/lib/ui/widgets/radio_station_card.dart
@@ -49,6 +49,7 @@ class _RadioStationCardState extends State<RadioStationCard> {
                         width: _cardWidth,
                         height: _cardWidth,
                         fit: BoxFit.cover,
+                        placeholder: (_, __) => _defaultIcon(),
                         errorWidget: (_, __, ___) => _defaultIcon(),
                       )
                     : _defaultIcon(),

--- a/lib/ui/widgets/widgets.dart
+++ b/lib/ui/widgets/widgets.dart
@@ -27,6 +27,7 @@ export 'playlist_row.dart';
 export 'podcast_card.dart';
 export 'profile_avatar.dart';
 export 'pull_to_refresh.dart';
+export 'radio_station_card.dart';
 export 'simple_playable_list.dart';
 export 'sliver_playable_list.dart';
 export 'song_card.dart';

--- a/test/providers/search_provider_test.dart
+++ b/test/providers/search_provider_test.dart
@@ -1,0 +1,42 @@
+import 'package:app/models/models.dart';
+import 'package:app/providers/search_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SearchResult', () {
+    test('has empty defaults', () {
+      final result = SearchResult();
+      expect(result.playables, isEmpty);
+      expect(result.artists, isEmpty);
+      expect(result.albums, isEmpty);
+      expect(result.podcasts, isEmpty);
+      expect(result.radioStations, isEmpty);
+    });
+
+    test('accepts radio stations', () {
+      final stations = [
+        RadioStation.fake(name: 'Jazz FM'),
+        RadioStation.fake(name: 'Rock Radio'),
+      ];
+
+      final result = SearchResult(radioStations: stations);
+      expect(result.radioStations, hasLength(2));
+      expect(result.radioStations[0].name, 'Jazz FM');
+      expect(result.radioStations[1].name, 'Rock Radio');
+    });
+
+    test('accepts all result types together', () {
+      final stations = [RadioStation.fake(name: 'Jazz FM')];
+
+      final result = SearchResult(
+        playables: [],
+        artists: [],
+        albums: [],
+        podcasts: [],
+        radioStations: stations,
+      );
+
+      expect(result.radioStations, hasLength(1));
+    });
+  });
+}

--- a/test/ui/widgets/radio_station_card_test.dart
+++ b/test/ui/widgets/radio_station_card_test.dart
@@ -1,0 +1,64 @@
+import 'package:app/models/radio_station.dart';
+import 'package:app/ui/widgets/radio_station_card.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../extensions/widget_tester_extension.dart';
+
+void main() {
+  testWidgets('renders station name', (WidgetTester tester) async {
+    final station = RadioStation.fake(name: 'Jazz FM');
+
+    await tester.pumpAppWidget(RadioStationCard(station: station));
+
+    expect(find.text('Jazz FM'), findsOneWidget);
+  });
+
+  testWidgets('renders description when present', (WidgetTester tester) async {
+    final station = RadioStation(
+      id: 'station-1',
+      name: 'Jazz FM',
+      url: 'https://stream.example.com/live',
+      description: 'The best jazz station',
+    );
+
+    await tester.pumpAppWidget(RadioStationCard(station: station));
+
+    expect(find.text('Jazz FM'), findsOneWidget);
+    expect(find.text('The best jazz station'), findsOneWidget);
+  });
+
+  testWidgets('does not render description when absent',
+      (WidgetTester tester) async {
+    final station = RadioStation.fake(name: 'Rock Radio');
+
+    await tester.pumpAppWidget(RadioStationCard(station: station));
+
+    expect(find.text('Rock Radio'), findsOneWidget);
+    // Only the name text widget should be present
+    expect(find.byType(Text), findsOneWidget);
+  });
+
+  testWidgets('shows default icon when no logo', (WidgetTester tester) async {
+    final station = RadioStation.fake(name: 'No Logo FM');
+
+    await tester.pumpAppWidget(RadioStationCard(station: station));
+
+    expect(
+      find.byIcon(CupertinoIcons.antenna_radiowaves_left_right),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('calls onTap when tapped', (WidgetTester tester) async {
+    var tapped = false;
+    final station = RadioStation.fake(name: 'Tap FM');
+
+    await tester.pumpAppWidget(
+      RadioStationCard(station: station, onTap: () => tapped = true),
+    );
+
+    await tester.tap(find.text('Tap FM'));
+    expect(tapped, isTrue);
+  });
+}

--- a/test/ui/widgets/radio_station_card_test.dart
+++ b/test/ui/widgets/radio_station_card_test.dart
@@ -1,5 +1,6 @@
 import 'package:app/models/radio_station.dart';
 import 'package:app/ui/widgets/radio_station_card.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -35,8 +36,24 @@ void main() {
     await tester.pumpAppWidget(RadioStationCard(station: station));
 
     expect(find.text('Rock Radio'), findsOneWidget);
-    // Only the name text widget should be present
-    expect(find.byType(Text), findsOneWidget);
+    expect(find.byType(CachedNetworkImage), findsNothing);
+  });
+
+  testWidgets('uses CachedNetworkImage when logo is present',
+      (WidgetTester tester) async {
+    final station = RadioStation(
+      id: 'station-1',
+      name: 'Logo FM',
+      url: 'https://stream.example.com/live',
+      logo: 'https://example.com/logo.png',
+    );
+
+    await tester.pumpAppWidget(RadioStationCard(station: station));
+
+    final image = tester.widget<CachedNetworkImage>(
+      find.byType(CachedNetworkImage),
+    );
+    expect(image.imageUrl, 'https://example.com/logo.png');
   });
 
   testWidgets('shows default icon when no logo', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary
- Parse `radio_stations` from the search API response into `SearchResult`
- Add `RadioStationCard` widget with logo support and fallback antenna icon
- Display a "Radio Stations" section in the search screen via `HorizontalCardScroller`
- Tapping a station card starts playback

## Test plan
- [x] `SearchResult` correctly stores radio stations (3 tests)
- [x] `RadioStationCard` renders name, description, icon, and handles tap (5 tests)
- [x] All 187 Flutter tests pass
- [ ] Backend `ExcerptSearchTest` updated to assert `radio_stations` in response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search results now include radio stations alongside albums, artists, and podcasts
  * Added radio station cards with logo, name, optional description, and animated tap feedback
  * Tap-to-play behavior for radio stations (default play action when tapped)

* **Tests**
  * Added tests for radio station search results and the radio station card display and interactions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->