### PR TITLE
Handle 'liked' field as int for older API versions

### DIFF
--- a/lib/models/interaction.dart
+++ b/lib/models/interaction.dart
@@ -13,7 +13,7 @@ class Interaction {
     return Interaction(
       songId: json['song_id'],
       playCount: json['play_count'],
-      liked: json['liked'] ?? false,
+      liked: json['liked'] is bool ? json['liked'] : (json['liked'] ?? 0) != 0,
     );
   }
 }

--- a/lib/models/song.dart
+++ b/lib/models/song.dart
@@ -148,7 +148,7 @@ class Song extends Playable<Song> {
       disc: json['disc'] ?? 1,
       year: json['year'] == null ? null : int.parse(json['year'].toString()),
       genre: json['genre'] ?? '',
-      liked: json['liked'] ?? false,
+      liked: json['liked'] is bool ? json['liked'] : (json['liked'] ?? 0) != 0,
     );
   }
 

--- a/test/models/song_test.dart
+++ b/test/models/song_test.dart
@@ -44,6 +44,29 @@ void main() {
       expect(song.albumCoverUrl, 'https://example.com/cover.jpg');
     });
 
+    test('handles liked as int for older API versions', () {
+      final jsonLiked = {
+        'id': 'abc-123',
+        'title': 'Test Song',
+        'length': 240,
+        'liked': 1,
+        'created_at': '2023-06-15T10:30:00.000Z',
+        'artist_id': 'a1',
+        'artist_name': 'Artist',
+        'album_id': 'b1',
+        'album_name': 'Album',
+        'album_cover': null,
+        'album_artist_id': 'a1',
+        'album_artist_name': 'Artist',
+      };
+
+      final jsonNotLiked = Map<String, dynamic>.from(jsonLiked)
+        ..['liked'] = 0;
+
+      expect(Song.fromJson(jsonLiked).liked, isTrue);
+      expect(Song.fromJson(jsonNotLiked).liked, isFalse);
+    });
+
     test('handles null optional fields', () {
       final json = {
         'id': 'abc-123',


### PR DESCRIPTION
## Summary
- Older Koel API versions return `liked` as an int (0/1) instead of a bool, causing a `type 'int' is not a subtype of type 'bool'` error
- Updated `Song.fromJson` and `Interaction.fromJson` to handle both types gracefully
- Added test coverage for the int-to-bool conversion

## Test plan
- [x] Existing tests pass
- [x] New test verifies int values (0 and 1) are correctly converted to bool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed liked status field parsing to properly handle both boolean and numeric data formats. The application now correctly interprets numeric representations as boolean values (non-zero = true, zero = false), improving data compatibility with various sources and ensuring consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->