### PR TITLE
Gate radio station features behind API v7.13.0

### DIFF
--- a/lib/ui/screens/library.dart
+++ b/lib/ui/screens/library.dart
@@ -72,13 +72,14 @@ class LibraryScreen extends StatelessWidget {
               CupertinoPageRoute(builder: (_) => const PodcastsScreen()),
             ),
           ),
-        LibraryMenuItem(
-          icon: CupertinoIcons.antenna_radiowaves_left_right,
-          label: 'Radio',
-          onTap: () => Navigator.of(context).push(
-            CupertinoPageRoute(builder: (_) => const RadioStationsScreen()),
+        if (Feature.radioStations.isSupported())
+          LibraryMenuItem(
+            icon: CupertinoIcons.antenna_radiowaves_left_right,
+            label: 'Radio',
+            onTap: () => Navigator.of(context).push(
+              CupertinoPageRoute(builder: (_) => const RadioStationsScreen()),
+            ),
           ),
-        ),
         LibraryMenuItem(
           icon: CupertinoIcons.cloud_download_fill,
           label: 'Downloaded',

--- a/lib/ui/screens/search.dart
+++ b/lib/ui/screens/search.dart
@@ -179,22 +179,24 @@ class _SearchScreenState extends State<SearchScreen> {
                               ),
                             ),
                         ],
-                        const SizedBox(height: 32),
-                        Padding(
-                          padding: const EdgeInsets.only(
-                            left: AppDimensions.hPadding,
-                          ),
-                          child: const Heading5(text: 'Radio Stations'),
-                        ),
-                        if (_radioStations.isEmpty)
-                          noResults
-                        else
-                          HorizontalCardScroller(
-                            cards: _radioStations.map(
-                              (station) =>
-                                  RadioStationCard(station: station),
+                        if (Feature.radioStations.isSupported()) ...[
+                          const SizedBox(height: 32),
+                          Padding(
+                            padding: const EdgeInsets.only(
+                              left: AppDimensions.hPadding,
                             ),
+                            child: const Heading5(text: 'Radio Stations'),
                           ),
+                          if (_radioStations.isEmpty)
+                            noResults
+                          else
+                            HorizontalCardScroller(
+                              cards: _radioStations.map(
+                                (station) =>
+                                    RadioStationCard(station: station),
+                              ),
+                            ),
+                        ],
                         const BottomSpace(asSliver: false),
                       ],
                     ),

--- a/lib/utils/features.dart
+++ b/lib/utils/features.dart
@@ -4,11 +4,13 @@ import 'package:version/version.dart';
 enum Feature {
   podcasts,
   queueStateSync,
+  radioStations,
 }
 
 Map<Feature, String> supportedVersionMap = {
   Feature.podcasts: '7.0.0',
-  Feature.queueStateSync: '6.11.6'
+  Feature.queueStateSync: '6.11.6',
+  Feature.radioStations: '7.13.0',
 };
 
 extension FeatureExtension on Feature {

--- a/test/utils/features_test.dart
+++ b/test/utils/features_test.dart
@@ -1,0 +1,41 @@
+import 'package:app/app_state.dart';
+import 'package:app/utils/features.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:version/version.dart';
+
+void main() {
+  setUp(() => AppState.clear());
+
+  group('Feature.radioStations', () {
+    test('is supported when API version is 7.13.0', () {
+      AppState.set(['app', 'apiVersion'], Version.parse('7.13.0'));
+      expect(Feature.radioStations.isSupported(), isTrue);
+    });
+
+    test('is supported when API version is above 7.13.0', () {
+      AppState.set(['app', 'apiVersion'], Version.parse('7.14.0'));
+      expect(Feature.radioStations.isSupported(), isTrue);
+    });
+
+    test('is not supported when API version is below 7.13.0', () {
+      AppState.set(['app', 'apiVersion'], Version.parse('7.12.0'));
+      expect(Feature.radioStations.isSupported(), isFalse);
+    });
+
+    test('is not supported when API version is not set', () {
+      expect(Feature.radioStations.isSupported(), isFalse);
+    });
+  });
+
+  group('Feature.podcasts', () {
+    test('is supported when API version is 7.0.0 or above', () {
+      AppState.set(['app', 'apiVersion'], Version.parse('7.0.0'));
+      expect(Feature.podcasts.isSupported(), isTrue);
+    });
+
+    test('is not supported when API version is below 7.0.0', () {
+      AppState.set(['app', 'apiVersion'], Version.parse('6.9.0'));
+      expect(Feature.podcasts.isSupported(), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Radio stations are only available since Koel v7.13.0
- Added `Feature.radioStations` to the existing feature flag system (same pattern as podcasts)
- Library menu item and search results section are now hidden for older API versions
- The search provider already handles missing `radio_stations` key gracefully

## Test plan
- [x] Unit tests for `Feature.radioStations.isSupported()` with various API versions
- [x] Verified radio items hidden when API version < 7.13.0
- [x] Verified radio items shown when API version >= 7.13.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Radio stations section now only displays when supported by the server version, preventing display of unavailable features across different platform instances.

* **Tests**
  * Added test coverage for feature support detection logic to ensure proper functionality across varying server versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->