### PR TITLE
Persist and restore navigation state across app restarts

### DIFF
--- a/lib/models/genre.dart
+++ b/lib/models/genre.dart
@@ -22,6 +22,13 @@ class Genre {
     );
   }
 
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'song_count': songCount,
+        'length': length,
+      };
+
   Genre merge(Genre remote) {
     this
       ..name = remote.name

--- a/lib/models/playlist.dart
+++ b/lib/models/playlist.dart
@@ -34,6 +34,15 @@ class Playlist {
     );
   }
 
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'is_smart': isSmart,
+        'folder_id': folderId,
+        'description': description,
+        'cover': cover,
+      };
+
   bool get hasCover => cover != null && cover!.isNotEmpty;
 
   factory Playlist.fake({

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -35,7 +35,10 @@ class AppRouter {
   }) async {
     await Navigator.of(context).push(CupertinoPageRoute(
       builder: (_) => const AlbumDetailsScreen(),
-      settings: RouteSettings(arguments: albumId),
+      settings: RouteSettings(
+        name: AlbumDetailsScreen.routeName,
+        arguments: albumId,
+      ),
     ));
   }
 
@@ -45,7 +48,10 @@ class AppRouter {
   }) async {
     await Navigator.of(context).push(CupertinoPageRoute(
       builder: (_) => const ArtistDetailsScreen(),
-      settings: RouteSettings(arguments: artistId),
+      settings: RouteSettings(
+        name: ArtistDetailsScreen.routeName,
+        arguments: artistId,
+      ),
     ));
   }
 
@@ -55,7 +61,10 @@ class AppRouter {
   }) async {
     await Navigator.of(context).push(CupertinoPageRoute(
       builder: (_) => const PodcastDetailsScreen(),
-      settings: RouteSettings(arguments: podcastId),
+      settings: RouteSettings(
+        name: PodcastDetailsScreen.routeName,
+        arguments: podcastId,
+      ),
     ));
   }
 
@@ -65,7 +74,10 @@ class AppRouter {
   }) async {
     await Navigator.of(context).push(CupertinoPageRoute(
       builder: (_) => const GenreDetailsScreen(),
-      settings: RouteSettings(arguments: genre),
+      settings: RouteSettings(
+        name: GenreDetailsScreen.routeName,
+        arguments: genre,
+      ),
     ));
   }
 

--- a/lib/ui/screens/home.dart
+++ b/lib/ui/screens/home.dart
@@ -127,10 +127,13 @@ class _HomeScreenState extends State<HomeScreen> {
                             children: [
                               IconButton(
                                 onPressed: () {
-                                  Navigator.of(
-                                    context,
-                                    rootNavigator: true,
-                                  ).pushNamed(RecentlyPlayedScreen.routeName);
+                                  Navigator.of(context).push(CupertinoPageRoute(
+                                    settings: const RouteSettings(
+                                      name: RecentlyPlayedScreen.routeName,
+                                    ),
+                                    builder: (_) =>
+                                        const RecentlyPlayedScreen(),
+                                  ));
                                 },
                                 icon: const Icon(CupertinoIcons.time, size: 23),
                               ),

--- a/lib/ui/screens/library.dart
+++ b/lib/ui/screens/library.dart
@@ -25,67 +25,76 @@ class LibraryScreen extends StatelessWidget {
         LibraryMenuItem(
           icon: CupertinoIcons.music_note,
           label: 'Songs',
-          onTap: () => Navigator.of(context).push(
-            CupertinoPageRoute(builder: (_) => const SongsScreen()),
-          ),
+          onTap: () => Navigator.of(context).push(CupertinoPageRoute(
+            settings: const RouteSettings(name: SongsScreen.routeName),
+            builder: (_) => const SongsScreen(),
+          )),
         ),
         LibraryMenuItem(
           icon: CupertinoIcons.star_fill,
           label: 'Favorites',
-          onTap: () => Navigator.of(context).push(
-            CupertinoPageRoute(builder: (_) => const FavoritesScreen()),
-          ),
+          onTap: () => Navigator.of(context).push(CupertinoPageRoute(
+            settings: const RouteSettings(name: FavoritesScreen.routeName),
+            builder: (_) => const FavoritesScreen(),
+          )),
         ),
         LibraryMenuItem(
           icon: CupertinoIcons.music_note_list,
           label: 'Playlists',
-          onTap: () => Navigator.of(context).push(
-            CupertinoPageRoute(builder: (_) => const PlaylistsScreen()),
-          ),
+          onTap: () => Navigator.of(context).push(CupertinoPageRoute(
+            settings: const RouteSettings(name: PlaylistsScreen.routeName),
+            builder: (_) => const PlaylistsScreen(),
+          )),
         ),
         LibraryMenuItem(
           icon: CupertinoIcons.music_mic,
           label: 'Artists',
-          onTap: () => Navigator.of(context).push(
-            CupertinoPageRoute(builder: (_) => const ArtistsScreen()),
-          ),
+          onTap: () => Navigator.of(context).push(CupertinoPageRoute(
+            settings: const RouteSettings(name: ArtistsScreen.routeName),
+            builder: (_) => const ArtistsScreen(),
+          )),
         ),
         LibraryMenuItem(
           icon: CupertinoIcons.music_albums,
           label: 'Albums',
-          onTap: () => Navigator.of(context).push(
-            CupertinoPageRoute(builder: (_) => const AlbumsScreen()),
-          ),
+          onTap: () => Navigator.of(context).push(CupertinoPageRoute(
+            settings: const RouteSettings(name: AlbumsScreen.routeName),
+            builder: (_) => const AlbumsScreen(),
+          )),
         ),
         LibraryMenuItem(
           icon: CupertinoIcons.guitars,
           label: 'Genres',
-          onTap: () => Navigator.of(context).push(
-            CupertinoPageRoute(builder: (_) => const GenresScreen()),
-          ),
+          onTap: () => Navigator.of(context).push(CupertinoPageRoute(
+            settings: const RouteSettings(name: GenresScreen.routeName),
+            builder: (_) => const GenresScreen(),
+          )),
         ),
         if (Feature.podcasts.isSupported())
           LibraryMenuItem(
             icon: LucideIcons.podcast,
             label: 'Podcasts',
-            onTap: () => Navigator.of(context).push(
-              CupertinoPageRoute(builder: (_) => const PodcastsScreen()),
-            ),
+            onTap: () => Navigator.of(context).push(CupertinoPageRoute(
+              settings: const RouteSettings(name: PodcastsScreen.routeName),
+              builder: (_) => const PodcastsScreen(),
+            )),
           ),
         if (Feature.radioStations.isSupported())
           LibraryMenuItem(
             icon: CupertinoIcons.antenna_radiowaves_left_right,
             label: 'Radio',
-            onTap: () => Navigator.of(context).push(
-              CupertinoPageRoute(builder: (_) => const RadioStationsScreen()),
-            ),
+            onTap: () => Navigator.of(context).push(CupertinoPageRoute(
+              settings: const RouteSettings(name: RadioStationsScreen.routeName),
+              builder: (_) => const RadioStationsScreen(),
+            )),
           ),
         LibraryMenuItem(
           icon: CupertinoIcons.cloud_download_fill,
           label: 'Downloaded',
-          onTap: () => Navigator.of(context).push(
-            CupertinoPageRoute(builder: (_) => DownloadedScreen()),
-          ),
+          onTap: () => Navigator.of(context).push(CupertinoPageRoute(
+            settings: const RouteSettings(name: DownloadedScreen.routeName),
+            builder: (_) => DownloadedScreen(),
+          )),
         ),
       ],
     ).toList();

--- a/lib/ui/screens/main.dart
+++ b/lib/ui/screens/main.dart
@@ -8,6 +8,7 @@ import 'package:app/mixins/stream_subscriber.dart';
 import 'package:app/providers/providers.dart';
 import 'package:app/ui/screens/screens.dart';
 import 'package:app/ui/widgets/widgets.dart';
+import 'package:app/utils/route_state.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -24,13 +25,15 @@ class MainScreen extends StatefulWidget {
 
 class _MainScreenState extends State<MainScreen> {
   static const tabBarHeight = 60.0;
-  int _selectedIndex = 0;
+  late int _selectedIndex;
   var _isOffline = AppState.get('mode', AppMode.online) == AppMode.offline;
 
   final _navigatorKeys = List.generate(
     3,
     (_) => GlobalKey<NavigatorState>(),
   );
+
+  late final List<RouteStateObserver> _routeObservers;
 
   static const List<Widget> _widgetOptions = [
     const HomeScreen(),
@@ -43,6 +46,7 @@ class _MainScreenState extends State<MainScreen> {
       _navigatorKeys[index].currentState?.popUntil((route) => route.isFirst);
     } else {
       setState(() => _selectedIndex = index);
+      RouteState.setTabIndex(index);
     }
   }
 
@@ -50,12 +54,48 @@ class _MainScreenState extends State<MainScreen> {
   void initState() {
     super.initState();
 
+    RouteState.load();
+    _selectedIndex = RouteState.tabIndex;
+    _routeObservers = List.generate(
+      3,
+      (i) => RouteStateObserver(tabIndex: i),
+    );
+
     audioHandler.init(
       playableProvider: context.read<PlayableProvider>(),
       downloadProvider: context.read<DownloadProvider>(),
     );
 
     context.read<DownloadSyncProvider>().scheduleSync();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) => _restoreRoutes());
+  }
+
+  void _restoreRoutes() {
+    // Take a snapshot of the persisted stacks, then clear them.
+    // The observer's didPush calls will re-populate them as routes are pushed.
+    final savedStacks = <int, List<RouteEntry>>{};
+    for (var tab = 0; tab < 3; tab++) {
+      savedStacks[tab] = List.of(RouteState.stackFor(tab));
+    }
+    RouteState.clear();
+    RouteState.setTabIndex(_selectedIndex);
+
+    for (var tab = 0; tab < 3; tab++) {
+      final stack = savedStacks[tab]!;
+      final navigator = _navigatorKeys[tab].currentState;
+      if (navigator == null || stack.isEmpty) continue;
+
+      for (final entry in stack) {
+        final screen = entry.buildScreen();
+        if (screen == null) continue;
+
+        navigator.push(CupertinoPageRoute(
+          settings: RouteSettings(name: entry.name, arguments: entry.argument),
+          builder: (_) => screen,
+        ));
+      }
+    }
   }
 
   BottomNavigationBarItem tabBarItem({
@@ -102,6 +142,7 @@ class _MainScreenState extends State<MainScreen> {
                   tabBuilder: (_, index) {
                     return CupertinoTabView(
                         navigatorKey: _navigatorKeys[index],
+                        navigatorObservers: [_routeObservers[index]],
                         builder: (_) => _widgetOptions[index]);
                   },
                   tabBar: CupertinoTabBar(

--- a/lib/ui/screens/main.dart
+++ b/lib/ui/screens/main.dart
@@ -88,7 +88,10 @@ class _MainScreenState extends State<MainScreen> {
 
       for (final entry in stack) {
         final screen = entry.buildScreen();
-        if (screen == null) continue;
+        if (screen == null) {
+          debugPrint('RouteState: unknown route "${entry.name}", skipping');
+          continue;
+        }
 
         navigator.push(CupertinoPageRoute(
           settings: RouteSettings(name: entry.name, arguments: entry.argument),

--- a/lib/ui/screens/playlist_details.dart
+++ b/lib/ui/screens/playlist_details.dart
@@ -9,6 +9,7 @@ import 'package:app/values/values.dart';
 import 'dart:ui';
 
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart' hide AppBar;
 import 'package:provider/provider.dart';
 
@@ -159,8 +160,11 @@ class _PlaylistDetailsScreen extends State<PlaylistDetailsScreen> {
 }
 
 void gotoDetailsScreen(BuildContext context, {required Playlist playlist}) {
-  Navigator.of(context, rootNavigator: true).pushNamed(
-    PlaylistDetailsScreen.routeName,
-    arguments: playlist,
-  );
+  Navigator.of(context).push(CupertinoPageRoute(
+    settings: RouteSettings(
+      name: PlaylistDetailsScreen.routeName,
+      arguments: playlist,
+    ),
+    builder: (_) => const PlaylistDetailsScreen(),
+  ));
 }

--- a/lib/ui/widgets/oops_box.dart
+++ b/lib/ui/widgets/oops_box.dart
@@ -1,5 +1,6 @@
 import 'package:app/providers/providers.dart';
 import 'package:app/ui/screens/screens.dart';
+import 'package:app/utils/route_state.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -58,6 +59,7 @@ class OopsBox extends StatelessWidget {
                       key: logOutButtonKey,
                       onPressed: () async {
                         await auth.logout();
+                        RouteState.clear();
                         await Navigator.of(
                           context,
                           rootNavigator: true,

--- a/lib/ui/widgets/profile_avatar.dart
+++ b/lib/ui/widgets/profile_avatar.dart
@@ -1,6 +1,7 @@
 import 'package:app/main.dart';
 import 'package:app/providers/providers.dart';
 import 'package:app/ui/screens/screens.dart';
+import 'package:app/utils/route_state.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -30,6 +31,7 @@ class ProfileAvatar extends StatelessWidget {
               onPressed: () async {
                 await context.read<AuthProvider>().logout();
                 await audioHandler.cleanUpUponLogout();
+                RouteState.clear();
                 Navigator.of(
                   context,
                   rootNavigator: true,

--- a/lib/utils/route_state.dart
+++ b/lib/utils/route_state.dart
@@ -86,9 +86,12 @@ class RouteStateObserver extends NavigatorObserver {
 
   RouteStateObserver({required this.tabIndex});
 
+  bool _isTracked(Route? route) =>
+      route?.settings.name != null && route!.settings.name != '/';
+
   @override
   void didPush(Route route, Route? previousRoute) {
-    if (route.settings.name != null && route.settings.name != '/') {
+    if (_isTracked(route)) {
       RouteState.addEntry(
         tabIndex,
         RouteEntry(name: route.settings.name!, argument: route.settings.arguments),
@@ -98,9 +101,33 @@ class RouteStateObserver extends NavigatorObserver {
 
   @override
   void didPop(Route route, Route? previousRoute) {
-    if (route.settings.name != null && route.settings.name != '/') {
+    if (!_isTracked(route)) return;
+    final stack = RouteState.stackFor(tabIndex);
+    if (stack.isNotEmpty && stack.last.name == route.settings.name) {
       RouteState.removeLastEntry(tabIndex);
     }
+  }
+
+  @override
+  void didReplace({Route? newRoute, Route? oldRoute}) {
+    if (_isTracked(oldRoute)) {
+      RouteState.removeLastEntry(tabIndex);
+    }
+    if (_isTracked(newRoute)) {
+      RouteState.addEntry(
+        tabIndex,
+        RouteEntry(
+          name: newRoute!.settings.name!,
+          argument: newRoute.settings.arguments,
+        ),
+      );
+    }
+  }
+
+  @override
+  void didRemove(Route route, Route? previousRoute) {
+    if (!_isTracked(route)) return;
+    RouteState.removeEntryByName(tabIndex, route.settings.name!);
   }
 }
 
@@ -126,6 +153,15 @@ class RouteState {
   static void removeLastEntry(int tab) {
     if (_stacks[tab] != null && _stacks[tab]!.isNotEmpty) {
       _stacks[tab]!.removeLast();
+      _persist();
+    }
+  }
+
+  static void removeEntryByName(int tab, String name) {
+    if (_stacks[tab] == null) return;
+    final idx = _stacks[tab]!.lastIndexWhere((e) => e.name == name);
+    if (idx >= 0) {
+      _stacks[tab]!.removeAt(idx);
       _persist();
     }
   }

--- a/lib/utils/route_state.dart
+++ b/lib/utils/route_state.dart
@@ -1,0 +1,173 @@
+import 'dart:convert';
+
+import 'package:app/models/models.dart';
+import 'package:app/ui/screens/screens.dart';
+import 'package:app/utils/preferences.dart' as preferences;
+import 'package:flutter/cupertino.dart';
+
+class RouteEntry {
+  final String name;
+  final dynamic argument;
+
+  const RouteEntry({required this.name, this.argument});
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'argument': _serializeArgument(),
+      };
+
+  factory RouteEntry.fromJson(Map<String, dynamic> json) {
+    return RouteEntry(
+      name: json['name'],
+      argument: _deserializeArgument(json['name'], json['argument']),
+    );
+  }
+
+  dynamic _serializeArgument() {
+    if (argument == null) return null;
+    if (argument is Playlist) return (argument as Playlist).toJson();
+    if (argument is Genre) return (argument as Genre).toJson();
+    return argument; // IDs (String, int) are already serializable
+  }
+
+  static dynamic _deserializeArgument(String routeName, dynamic data) {
+    if (data == null) return null;
+
+    switch (routeName) {
+      case PlaylistDetailsScreen.routeName:
+        return Playlist.fromJson(Map<String, dynamic>.from(data));
+      case GenreDetailsScreen.routeName:
+        return Genre.fromJson(Map<String, dynamic>.from(data));
+      default:
+        return data; // IDs
+    }
+  }
+
+  Widget? buildScreen() {
+    switch (name) {
+      case SongsScreen.routeName:
+        return const SongsScreen();
+      case FavoritesScreen.routeName:
+        return const FavoritesScreen();
+      case PlaylistsScreen.routeName:
+        return const PlaylistsScreen();
+      case ArtistsScreen.routeName:
+        return const ArtistsScreen();
+      case AlbumsScreen.routeName:
+        return const AlbumsScreen();
+      case GenresScreen.routeName:
+        return const GenresScreen();
+      case PodcastsScreen.routeName:
+        return const PodcastsScreen();
+      case RadioStationsScreen.routeName:
+        return const RadioStationsScreen();
+      case DownloadedScreen.routeName:
+        return DownloadedScreen();
+      case RecentlyPlayedScreen.routeName:
+        return const RecentlyPlayedScreen();
+      case AlbumDetailsScreen.routeName:
+        return const AlbumDetailsScreen();
+      case ArtistDetailsScreen.routeName:
+        return const ArtistDetailsScreen();
+      case PlaylistDetailsScreen.routeName:
+        return const PlaylistDetailsScreen();
+      case PodcastDetailsScreen.routeName:
+        return const PodcastDetailsScreen();
+      case GenreDetailsScreen.routeName:
+        return const GenreDetailsScreen();
+      default:
+        return null;
+    }
+  }
+}
+
+class RouteStateObserver extends NavigatorObserver {
+  final int tabIndex;
+
+  RouteStateObserver({required this.tabIndex});
+
+  @override
+  void didPush(Route route, Route? previousRoute) {
+    if (route.settings.name != null && route.settings.name != '/') {
+      RouteState.addEntry(
+        tabIndex,
+        RouteEntry(name: route.settings.name!, argument: route.settings.arguments),
+      );
+    }
+  }
+
+  @override
+  void didPop(Route route, Route? previousRoute) {
+    if (route.settings.name != null && route.settings.name != '/') {
+      RouteState.removeLastEntry(tabIndex);
+    }
+  }
+}
+
+class RouteState {
+  static const _storageKey = 'routeState';
+  static var _tabIndex = 0;
+  static var _stacks = <int, List<RouteEntry>>{0: [], 1: [], 2: []};
+
+  static int get tabIndex => _tabIndex;
+  static List<RouteEntry> stackFor(int tab) => _stacks[tab] ?? [];
+
+  static void setTabIndex(int index) {
+    _tabIndex = index;
+    _persist();
+  }
+
+  static void addEntry(int tab, RouteEntry entry) {
+    _stacks[tab] ??= [];
+    _stacks[tab]!.add(entry);
+    _persist();
+  }
+
+  static void removeLastEntry(int tab) {
+    if (_stacks[tab] != null && _stacks[tab]!.isNotEmpty) {
+      _stacks[tab]!.removeLast();
+      _persist();
+    }
+  }
+
+  static void _persist() {
+    final data = {
+      'tabIndex': _tabIndex,
+      'stacks': _stacks.map(
+        (tab, entries) => MapEntry(
+          tab.toString(),
+          entries.map((e) => e.toJson()).toList(),
+        ),
+      ),
+    };
+    preferences.storage.write(_storageKey, jsonEncode(data));
+  }
+
+  static void load() {
+    final raw = preferences.storage.read<String>(_storageKey);
+    if (raw == null) return;
+
+    try {
+      final data = jsonDecode(raw) as Map<String, dynamic>;
+      _tabIndex = data['tabIndex'] ?? 0;
+
+      final stacks = data['stacks'] as Map<String, dynamic>? ?? {};
+      _stacks = {};
+      for (final entry in stacks.entries) {
+        final tab = int.parse(entry.key);
+        _stacks[tab] = (entry.value as List)
+            .map((e) => RouteEntry.fromJson(Map<String, dynamic>.from(e)))
+            .toList();
+      }
+    } catch (_) {
+      _tabIndex = 0;
+      _stacks = {0: [], 1: [], 2: []};
+    }
+  }
+
+  static void clear() {
+    _tabIndex = 0;
+    _stacks = {0: [], 1: [], 2: []};
+    preferences.storage.remove(_storageKey);
+  }
+}

--- a/lib/utils/route_state.dart
+++ b/lib/utils/route_state.dart
@@ -190,7 +190,8 @@ class RouteState {
 
     try {
       final data = jsonDecode(raw) as Map<String, dynamic>;
-      _tabIndex = data['tabIndex'] ?? 0;
+      final t = data['tabIndex'];
+      _tabIndex = t is int ? t : 0;
 
       final stacks = data['stacks'] as Map<String, dynamic>? ?? {};
       _stacks = {};

--- a/lib/utils/route_state.dart
+++ b/lib/utils/route_state.dart
@@ -135,6 +135,9 @@ class RouteState {
   static const _storageKey = 'routeState';
   static var _tabIndex = 0;
   static var _stacks = <int, List<RouteEntry>>{0: [], 1: [], 2: []};
+  /// Set to false to disable storage persistence (e.g. in tests).
+  static set persistEnabled(bool value) => _persistEnabled = value;
+  static var _persistEnabled = true;
 
   static int get tabIndex => _tabIndex;
   static List<RouteEntry> stackFor(int tab) => _stacks[tab] ?? [];
@@ -167,6 +170,7 @@ class RouteState {
   }
 
   static void _persist() {
+    if (!_persistEnabled) return;
     final data = {
       'tabIndex': _tabIndex,
       'stacks': _stacks.map(
@@ -180,6 +184,7 @@ class RouteState {
   }
 
   static void load() {
+    if (!_persistEnabled) return;
     final raw = preferences.storage.read<String>(_storageKey);
     if (raw == null) return;
 
@@ -202,8 +207,15 @@ class RouteState {
   }
 
   static void clear() {
+    reset();
+    if (_persistEnabled) {
+      preferences.storage.remove(_storageKey);
+    }
+  }
+
+  /// Resets in-memory state without touching storage.
+  static void reset() {
     _tabIndex = 0;
     _stacks = {0: [], 1: [], 2: []};
-    preferences.storage.remove(_storageKey);
   }
 }

--- a/test/utils/route_state_test.dart
+++ b/test/utils/route_state_test.dart
@@ -1,0 +1,186 @@
+import 'package:app/models/models.dart';
+import 'package:app/ui/screens/screens.dart';
+import 'package:app/utils/route_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('RouteEntry serialization', () {
+    test('round-trips a route with no argument', () {
+      final entry = RouteEntry(name: SongsScreen.routeName);
+      final json = entry.toJson();
+      final restored = RouteEntry.fromJson(json);
+
+      expect(restored.name, SongsScreen.routeName);
+      expect(restored.argument, isNull);
+    });
+
+    test('round-trips a route with a string ID argument', () {
+      final entry = RouteEntry(
+        name: AlbumDetailsScreen.routeName,
+        argument: 'album-123',
+      );
+      final json = entry.toJson();
+      final restored = RouteEntry.fromJson(json);
+
+      expect(restored.name, AlbumDetailsScreen.routeName);
+      expect(restored.argument, 'album-123');
+    });
+
+    test('round-trips a route with an int ID argument', () {
+      final entry = RouteEntry(
+        name: ArtistDetailsScreen.routeName,
+        argument: 42,
+      );
+      final json = entry.toJson();
+      final restored = RouteEntry.fromJson(json);
+
+      expect(restored.name, ArtistDetailsScreen.routeName);
+      expect(restored.argument, 42);
+    });
+
+    test('round-trips a route with a Playlist argument', () {
+      final playlist = Playlist.fake(
+        id: 'pl-1',
+        name: 'My Playlist',
+        isSmart: false,
+      );
+      final entry = RouteEntry(
+        name: PlaylistDetailsScreen.routeName,
+        argument: playlist,
+      );
+      final json = entry.toJson();
+      final restored = RouteEntry.fromJson(json);
+
+      expect(restored.name, PlaylistDetailsScreen.routeName);
+      expect(restored.argument, isA<Playlist>());
+      final restoredPlaylist = restored.argument as Playlist;
+      expect(restoredPlaylist.id, 'pl-1');
+      expect(restoredPlaylist.name, 'My Playlist');
+      expect(restoredPlaylist.isSmart, isFalse);
+    });
+
+    test('round-trips a route with a Genre argument', () {
+      final genre = Genre(
+        id: 'g-1',
+        name: 'Rock',
+        songCount: 42,
+        length: 12345,
+      );
+      final entry = RouteEntry(
+        name: GenreDetailsScreen.routeName,
+        argument: genre,
+      );
+      final json = entry.toJson();
+      final restored = RouteEntry.fromJson(json);
+
+      expect(restored.name, GenreDetailsScreen.routeName);
+      expect(restored.argument, isA<Genre>());
+      final restoredGenre = restored.argument as Genre;
+      expect(restoredGenre.id, 'g-1');
+      expect(restoredGenre.name, 'Rock');
+      expect(restoredGenre.songCount, 42);
+    });
+
+    test('round-trips a podcast ID argument', () {
+      final entry = RouteEntry(
+        name: PodcastDetailsScreen.routeName,
+        argument: 'podcast-abc',
+      );
+      final json = entry.toJson();
+      final restored = RouteEntry.fromJson(json);
+
+      expect(restored.name, PodcastDetailsScreen.routeName);
+      expect(restored.argument, 'podcast-abc');
+    });
+  });
+
+  group('RouteEntry.buildScreen', () {
+    test('returns correct screen for library routes', () {
+      expect(
+        RouteEntry(name: SongsScreen.routeName).buildScreen(),
+        isA<SongsScreen>(),
+      );
+      expect(
+        RouteEntry(name: FavoritesScreen.routeName).buildScreen(),
+        isA<FavoritesScreen>(),
+      );
+      expect(
+        RouteEntry(name: PlaylistsScreen.routeName).buildScreen(),
+        isA<PlaylistsScreen>(),
+      );
+      expect(
+        RouteEntry(name: ArtistsScreen.routeName).buildScreen(),
+        isA<ArtistsScreen>(),
+      );
+      expect(
+        RouteEntry(name: AlbumsScreen.routeName).buildScreen(),
+        isA<AlbumsScreen>(),
+      );
+      expect(
+        RouteEntry(name: GenresScreen.routeName).buildScreen(),
+        isA<GenresScreen>(),
+      );
+    });
+
+    test('returns correct screen for detail routes', () {
+      expect(
+        RouteEntry(name: AlbumDetailsScreen.routeName).buildScreen(),
+        isA<AlbumDetailsScreen>(),
+      );
+      expect(
+        RouteEntry(name: ArtistDetailsScreen.routeName).buildScreen(),
+        isA<ArtistDetailsScreen>(),
+      );
+      expect(
+        RouteEntry(name: PlaylistDetailsScreen.routeName).buildScreen(),
+        isA<PlaylistDetailsScreen>(),
+      );
+      expect(
+        RouteEntry(name: PodcastDetailsScreen.routeName).buildScreen(),
+        isA<PodcastDetailsScreen>(),
+      );
+      expect(
+        RouteEntry(name: GenreDetailsScreen.routeName).buildScreen(),
+        isA<GenreDetailsScreen>(),
+      );
+    });
+
+    test('returns null for unknown route', () {
+      expect(RouteEntry(name: '/unknown').buildScreen(), isNull);
+    });
+  });
+
+  group('Playlist.toJson', () {
+    test('round-trips through JSON', () {
+      final original = Playlist.fake(
+        id: 'test-id',
+        name: 'Test Playlist',
+        isSmart: true,
+      );
+      final json = original.toJson();
+      final restored = Playlist.fromJson(json);
+
+      expect(restored.id, original.id);
+      expect(restored.name, original.name);
+      expect(restored.isSmart, original.isSmart);
+    });
+  });
+
+  group('Genre.toJson', () {
+    test('round-trips through JSON', () {
+      final original = Genre(
+        id: 'rock',
+        name: 'Rock',
+        songCount: 100,
+        length: 36000,
+      );
+      final json = original.toJson();
+      final restored = Genre.fromJson(json);
+
+      expect(restored.id, original.id);
+      expect(restored.name, original.name);
+      expect(restored.songCount, original.songCount);
+      expect(restored.length, original.length);
+    });
+  });
+}

--- a/test/utils/route_state_test.dart
+++ b/test/utils/route_state_test.dart
@@ -365,6 +365,23 @@ void main() {
       expect(restored.name, original.name);
       expect(restored.isSmart, original.isSmart);
     });
+
+    test('round-trips nullable fields', () {
+      final original = Playlist.fake(
+        id: 'test-id',
+        name: 'Test Playlist',
+        isSmart: false,
+        folderId: 'folder-1',
+        description: 'A test playlist',
+        cover: 'https://example.com/cover.jpg',
+      );
+      final json = original.toJson();
+      final restored = Playlist.fromJson(json);
+
+      expect(restored.folderId, 'folder-1');
+      expect(restored.description, 'A test playlist');
+      expect(restored.cover, 'https://example.com/cover.jpg');
+    });
   });
 
   group('Genre.toJson', () {

--- a/test/utils/route_state_test.dart
+++ b/test/utils/route_state_test.dart
@@ -1,9 +1,20 @@
 import 'package:app/models/models.dart';
 import 'package:app/ui/screens/screens.dart';
 import 'package:app/utils/route_state.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+/// A minimal [Route] implementation for testing [RouteStateObserver].
+class FakeRoute extends Route {
+  FakeRoute({required String name, dynamic arguments})
+      : super(settings: RouteSettings(name: name, arguments: arguments));
+}
+
 void main() {
+  RouteState.persistEnabled = false;
+
+  setUp(() => RouteState.reset());
+
   group('RouteEntry serialization', () {
     test('round-trips a route with no argument', () {
       final entry = RouteEntry(name: SongsScreen.routeName);
@@ -147,6 +158,196 @@ void main() {
 
     test('returns null for unknown route', () {
       expect(RouteEntry(name: '/unknown').buildScreen(), isNull);
+    });
+  });
+
+  group('RouteState', () {
+    setUp(() => RouteState.reset());
+
+    test('defaults to tab 0 with empty stacks', () {
+      expect(RouteState.tabIndex, 0);
+      expect(RouteState.stackFor(0), isEmpty);
+      expect(RouteState.stackFor(1), isEmpty);
+      expect(RouteState.stackFor(2), isEmpty);
+    });
+
+    test('setTabIndex updates tab index', () {
+      RouteState.setTabIndex(2);
+      expect(RouteState.tabIndex, 2);
+    });
+
+    test('addEntry appends to the correct tab stack', () {
+      RouteState.addEntry(1, RouteEntry(name: '/songs'));
+      RouteState.addEntry(1, RouteEntry(name: '/albums'));
+
+      expect(RouteState.stackFor(1).length, 2);
+      expect(RouteState.stackFor(1)[0].name, '/songs');
+      expect(RouteState.stackFor(1)[1].name, '/albums');
+      expect(RouteState.stackFor(0), isEmpty);
+    });
+
+    test('removeLastEntry removes the last entry', () {
+      RouteState.addEntry(0, RouteEntry(name: '/songs'));
+      RouteState.addEntry(0, RouteEntry(name: '/albums'));
+
+      RouteState.removeLastEntry(0);
+
+      expect(RouteState.stackFor(0).length, 1);
+      expect(RouteState.stackFor(0).first.name, '/songs');
+    });
+
+    test('removeLastEntry does nothing on empty stack', () {
+      RouteState.removeLastEntry(0);
+      expect(RouteState.stackFor(0), isEmpty);
+    });
+
+    test('removeEntryByName removes the matching entry', () {
+      RouteState.addEntry(0, RouteEntry(name: '/songs'));
+      RouteState.addEntry(0, RouteEntry(name: '/albums'));
+      RouteState.addEntry(0, RouteEntry(name: '/album'));
+
+      RouteState.removeEntryByName(0, '/albums');
+
+      expect(RouteState.stackFor(0).length, 2);
+      expect(RouteState.stackFor(0)[0].name, '/songs');
+      expect(RouteState.stackFor(0)[1].name, '/album');
+    });
+
+    test('removeEntryByName removes last occurrence when duplicates exist', () {
+      RouteState.addEntry(0, RouteEntry(name: '/songs'));
+      RouteState.addEntry(0, RouteEntry(name: '/songs'));
+
+      RouteState.removeEntryByName(0, '/songs');
+
+      expect(RouteState.stackFor(0).length, 1);
+      expect(RouteState.stackFor(0).first.name, '/songs');
+    });
+
+    test('removeEntryByName does nothing for non-existent name', () {
+      RouteState.addEntry(0, RouteEntry(name: '/songs'));
+      RouteState.removeEntryByName(0, '/unknown');
+      expect(RouteState.stackFor(0).length, 1);
+    });
+
+    test('reset clears in-memory state', () {
+      RouteState.setTabIndex(1);
+      RouteState.addEntry(1, RouteEntry(name: '/songs'));
+
+      RouteState.reset();
+
+      expect(RouteState.tabIndex, 0);
+      expect(RouteState.stackFor(0), isEmpty);
+      expect(RouteState.stackFor(1), isEmpty);
+    });
+  });
+
+  group('RouteStateObserver', () {
+    late RouteStateObserver observer;
+
+    setUp(() {
+      RouteState.reset();
+      observer = RouteStateObserver(tabIndex: 0);
+    });
+
+    test('didPush adds entry to stack', () {
+      observer.didPush(FakeRoute(name: '/songs'), null);
+
+      expect(RouteState.stackFor(0).length, 1);
+      expect(RouteState.stackFor(0).first.name, '/songs');
+    });
+
+    test('didPush ignores root route', () {
+      observer.didPush(FakeRoute(name: '/'), null);
+      expect(RouteState.stackFor(0), isEmpty);
+    });
+
+    test('didPush preserves arguments', () {
+      observer.didPush(
+        FakeRoute(name: '/album', arguments: 'album-42'),
+        null,
+      );
+
+      expect(RouteState.stackFor(0).first.argument, 'album-42');
+    });
+
+    test('didPop removes matching top entry', () {
+      observer.didPush(FakeRoute(name: '/songs'), null);
+      observer.didPush(FakeRoute(name: '/albums'), null);
+
+      observer.didPop(FakeRoute(name: '/albums'), null);
+
+      expect(RouteState.stackFor(0).length, 1);
+      expect(RouteState.stackFor(0).first.name, '/songs');
+    });
+
+    test('didPop does not remove if name does not match stack top', () {
+      observer.didPush(FakeRoute(name: '/songs'), null);
+      observer.didPush(FakeRoute(name: '/albums'), null);
+
+      // Pop a route that doesn't match the top (/albums)
+      observer.didPop(FakeRoute(name: '/songs'), null);
+
+      // Stack should remain unchanged
+      expect(RouteState.stackFor(0).length, 2);
+    });
+
+    test('didPop ignores root route', () {
+      observer.didPush(FakeRoute(name: '/songs'), null);
+      observer.didPop(FakeRoute(name: '/'), null);
+      expect(RouteState.stackFor(0).length, 1);
+    });
+
+    test('didReplace swaps the top entry', () {
+      observer.didPush(FakeRoute(name: '/songs'), null);
+
+      observer.didReplace(
+        newRoute: FakeRoute(name: '/albums'),
+        oldRoute: FakeRoute(name: '/songs'),
+      );
+
+      expect(RouteState.stackFor(0).length, 1);
+      expect(RouteState.stackFor(0).first.name, '/albums');
+    });
+
+    test('didReplace handles null oldRoute (add only)', () {
+      observer.didReplace(
+        newRoute: FakeRoute(name: '/songs'),
+        oldRoute: null,
+      );
+
+      expect(RouteState.stackFor(0).length, 1);
+      expect(RouteState.stackFor(0).first.name, '/songs');
+    });
+
+    test('didRemove removes matching entry from middle of stack', () {
+      observer.didPush(FakeRoute(name: '/songs'), null);
+      observer.didPush(FakeRoute(name: '/albums'), null);
+      observer.didPush(FakeRoute(name: '/album'), null);
+
+      observer.didRemove(FakeRoute(name: '/albums'), null);
+
+      expect(RouteState.stackFor(0).length, 2);
+      expect(RouteState.stackFor(0)[0].name, '/songs');
+      expect(RouteState.stackFor(0)[1].name, '/album');
+    });
+
+    test('didRemove ignores root route', () {
+      observer.didPush(FakeRoute(name: '/songs'), null);
+      observer.didRemove(FakeRoute(name: '/'), null);
+      expect(RouteState.stackFor(0).length, 1);
+    });
+
+    test('tracks correct tab index', () {
+      final observer1 = RouteStateObserver(tabIndex: 1);
+      final observer2 = RouteStateObserver(tabIndex: 2);
+
+      observer.didPush(FakeRoute(name: '/songs'), null);
+      observer1.didPush(FakeRoute(name: '/albums'), null);
+      observer2.didPush(FakeRoute(name: '/album'), null);
+
+      expect(RouteState.stackFor(0).first.name, '/songs');
+      expect(RouteState.stackFor(1).first.name, '/albums');
+      expect(RouteState.stackFor(2).first.name, '/album');
     });
   });
 


### PR DESCRIPTION
## Summary
- Saves the active tab index and full route stack per tab to GetStorage
- On relaunch, restores the exact navigation state (e.g. Library > Albums > Album Details)
- Uses `NavigatorObserver` per tab to automatically track route pushes/pops
- Adds `RouteSettings` with route names to all `CupertinoPageRoute` pushes
- Adds `toJson` to `Playlist` and `Genre` for route argument serialization
- Clears route state on logout

## How it works
1. `RouteStateObserver` (one per tab) watches `didPush`/`didPop` and persists the stack
2. On `MainScreen.initState`, `RouteState.load()` reads persisted state
3. `_restoreRoutes()` replays the saved route stack into each tab's navigator
4. Route arguments (IDs, Playlist, Genre) are serialized/deserialized as JSON

## Test plan
- [x] All 206 tests pass
- [x] RouteEntry serialization round-trips for all argument types (null, string, int, Playlist, Genre)
- [x] RouteEntry.buildScreen returns correct widget for all known routes
- [x] Playlist.toJson and Genre.toJson round-trip correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent tabbed navigation with per-tab history saved and restored.
  * JSON serialization added for playlists and genres.

* **Bug Fixes**
  * Navigation state is cleared on logout to avoid stale routes.

* **Improvements**
  * Navigation now records explicit route names/metadata and consistently pushes pages to the correct navigator.
  * Some navigations updated to restore recorded stacks on startup.

* **Tests**
  * Added tests validating route-state behavior and model JSON round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->