### PR TITLE
Fix repeat-all mode causing current song to loop

### DIFF
--- a/lib/audio_handler.dart
+++ b/lib/audio_handler.dart
@@ -409,7 +409,11 @@ class KoelAudioHandler extends BaseAudioHandler with QueueHandler, SeekHandler {
   @override
   Future<void> setRepeatMode(AudioServiceRepeatMode repeatMode) async {
     playbackState.add(playbackState.value.copyWith(repeatMode: repeatMode));
-    await _player.setLoopMode(LoopMode.values[repeatMode.index]);
+    // Only pass LoopMode.one to the player for gapless single-track repeat.
+    // "Repeat all" is handled by the app's own queue logic in skipToNext().
+    await _player.setLoopMode(
+      repeatMode == AudioServiceRepeatMode.one ? LoopMode.one : LoopMode.off,
+    );
   }
 
   Future<void> cleanUpUponLogout() async {


### PR DESCRIPTION
## Summary
- "Repeat all" caused the current song to keep repeating instead of advancing to the next track
- Root cause: `setRepeatMode` passed `LoopMode.all` to just_audio's player, which loops the current audio source. The app already handles "repeat all" queue wrapping in `skipToNext()`, so these two mechanisms conflicted
- Fix: only pass `LoopMode.one` to the player for single-track repeat; use `LoopMode.off` for all other modes

## Test plan
- [x] All 227 tests pass
- [x] Repeat All: song advances to next track, wraps to beginning of queue
- [x] Repeat One: current song loops
- [x] No Repeat: queue stops at end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed audio repeat mode functionality to ensure cycling through repeat settings works correctly in the player.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->