### PR TITLE
Add gradient background to AddToPlaylistScreen

### DIFF
--- a/lib/ui/screens/add_to_playlist.dart
+++ b/lib/ui/screens/add_to_playlist.dart
@@ -24,7 +24,8 @@ class AddToPlaylistScreen extends StatelessWidget {
     final playable = ModalRoute.of(context)!.settings.arguments as Playable;
 
     return Scaffold(
-      body: CupertinoTheme(
+      body: GradientDecoratedContainer(
+        child: CupertinoTheme(
         data: const CupertinoThemeData(primaryColor: Colors.white),
         child: Consumer<PlaylistProvider>(
           builder: (context, provider, navigationBar) {
@@ -73,6 +74,7 @@ class AddToPlaylistScreen extends StatelessWidget {
             ),
           ),
         ),
+      ),
       ),
     );
   }

--- a/lib/ui/screens/add_to_playlist.dart
+++ b/lib/ui/screens/add_to_playlist.dart
@@ -26,55 +26,56 @@ class AddToPlaylistScreen extends StatelessWidget {
     return Scaffold(
       body: GradientDecoratedContainer(
         child: CupertinoTheme(
-        data: const CupertinoThemeData(primaryColor: Colors.white),
-        child: Consumer<PlaylistProvider>(
-          builder: (context, provider, navigationBar) {
-            if (provider.standardPlaylists.isEmpty) {
-              return NoPlaylistsScreen(
-                onTap: () => router.showCreatePlaylistSheet(context),
-              );
-            }
+          data: const CupertinoThemeData(primaryColor: Colors.white),
+          child: Consumer<PlaylistProvider>(
+            builder: (context, provider, navigationBar) {
+              if (provider.standardPlaylists.isEmpty) {
+                return NoPlaylistsScreen(
+                  onTap: () => router.showCreatePlaylistSheet(context),
+                );
+              }
 
-            return CustomScrollView(
-              slivers: <Widget>[
-                navigationBar!,
-                SliverList(
-                  delegate: SliverChildBuilderDelegate(
-                    (BuildContext context, int index) {
-                      Playlist playlist = provider.standardPlaylists[index];
+              return CustomScrollView(
+                slivers: <Widget>[
+                  navigationBar!,
+                  SliverList(
+                    delegate: SliverChildBuilderDelegate(
+                      (BuildContext context, int index) {
+                        Playlist playlist = provider.standardPlaylists[index];
 
-                      return PlaylistRow(
-                        playlist: playlist,
-                        onTap: () {
-                          provider.addToPlaylist(playable, playlist: playlist);
-                          HapticFeedback.mediumImpact();
-                          Navigator.pop(context);
-                          showOverlay(
-                            context,
-                            icon: CupertinoIcons.text_badge_plus,
-                            caption: 'Added',
-                            message: 'Item added to playlist.',
-                          );
-                        },
-                      );
-                    },
-                    childCount: provider.standardPlaylists.length,
+                        return PlaylistRow(
+                          playlist: playlist,
+                          onTap: () {
+                            provider.addToPlaylist(playable,
+                                playlist: playlist);
+                            HapticFeedback.mediumImpact();
+                            Navigator.pop(context);
+                            showOverlay(
+                              context,
+                              icon: CupertinoIcons.text_badge_plus,
+                              caption: 'Added',
+                              message: 'Item added to playlist.',
+                            );
+                          },
+                        );
+                      },
+                      childCount: provider.standardPlaylists.length,
+                    ),
                   ),
-                ),
-                const BottomSpace(),
-              ],
-            );
-          },
-          child: CupertinoSliverNavigationBar(
-            backgroundColor: AppColors.staticScreenHeaderBackground,
-            largeTitle: const LargeTitle(text: 'Add to a Playlist'),
-            trailing: IconButton(
-              onPressed: () => router.showCreatePlaylistSheet(context),
-              icon: const Icon(CupertinoIcons.add_circled),
+                  const BottomSpace(),
+                ],
+              );
+            },
+            child: CupertinoSliverNavigationBar(
+              backgroundColor: AppColors.staticScreenHeaderBackground,
+              largeTitle: const LargeTitle(text: 'Add to a Playlist'),
+              trailing: IconButton(
+                onPressed: () => router.showCreatePlaylistSheet(context),
+                icon: const Icon(CupertinoIcons.add_circled),
+              ),
             ),
           ),
         ),
-      ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- The AddToPlaylistScreen had a transparent background because the theme sets `scaffoldBackgroundColor: Colors.transparent`
- This caused both screens to be visible on top of each other during page transitions
- Fixed by wrapping the content with `GradientDecoratedContainer`, matching all other screens

## Test plan
- [x] All 227 tests pass
- [x] No more screen overlap during transition to/from the Add to Playlist screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the Add to Playlist screen with a gradient background decoration for improved visual polish.
  * Existing interactions and playlist behaviors remain unchanged (tapping, haptics, confirmations), so user flows are unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->