### PR TITLE
Fix downloaded songs losing their liked/favorite status

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,6 +38,7 @@ List<SingleChildWidget> _providers = [
     create: (context) => InteractionProvider(
       playableProvider: context.read<PlayableProvider>(),
       recentlyPlayedProvider: context.read<RecentlyPlayedProvider>(),
+      downloadProvider: context.read<DownloadProvider>(),
     ),
     // By setting lazy to false, we ensure that the provider is initialized
     // before the app is launched. This makes sure that the provider listens

--- a/lib/models/song.dart
+++ b/lib/models/song.dart
@@ -172,6 +172,7 @@ class Song extends Playable<Song> {
       'disc': disc,
       'year': year,
       'genre': genre,
+      'liked': liked,
     };
   }
 

--- a/lib/providers/download_provider.dart
+++ b/lib/providers/download_provider.dart
@@ -139,6 +139,10 @@ class DownloadProvider with StreamSubscriber {
     _playableStorage.write(serializedPlayableKey, playables);
   }
 
+  void persistMetadataIfNeeded(Playable playable) {
+    if (has(playable: playable)) persistMetadata();
+  }
+
   Future<void> removeForPlayable(Playable playable) async {
     _removePlayable(playable);
     _downloadRemoved.add(playable);

--- a/lib/providers/download_sync_provider.dart
+++ b/lib/providers/download_sync_provider.dart
@@ -106,7 +106,8 @@ class DownloadSyncProvider with ChangeNotifier {
         local.track != server.track ||
         local.disc != server.disc ||
         local.genre != server.genre ||
-        local.year != server.year;
+        local.year != server.year ||
+        local.liked != server.liked;
   }
 
   void dispose() {

--- a/lib/providers/interaction_provider.dart
+++ b/lib/providers/interaction_provider.dart
@@ -9,12 +9,15 @@ import 'package:flutter/foundation.dart';
 class InteractionProvider with ChangeNotifier, StreamSubscriber {
   late final PlayableProvider _playableProvider;
   late final RecentlyPlayedProvider _recentlyPlayedProvider;
+  late final DownloadProvider _downloadProvider;
 
   InteractionProvider({
     required PlayableProvider playableProvider,
     required RecentlyPlayedProvider recentlyPlayedProvider,
+    required DownloadProvider downloadProvider,
   })  : _playableProvider = playableProvider,
-        _recentlyPlayedProvider = recentlyPlayedProvider {
+        _recentlyPlayedProvider = recentlyPlayedProvider,
+        _downloadProvider = downloadProvider {
     _subscribeToAudioEvents();
   }
 
@@ -51,12 +54,14 @@ class InteractionProvider with ChangeNotifier, StreamSubscriber {
   Future<void> _like({required Song song}) async {
     song.liked = true;
     notifyListeners();
+    _downloadProvider.persistMetadataIfNeeded(song);
     await post('interaction/like', data: {'song': song.id});
   }
 
   Future<void> _unlike({required Song song}) async {
     song.liked = false;
     notifyListeners();
+    _downloadProvider.persistMetadataIfNeeded(song);
     await post('interaction/like', data: {'song': song.id});
   }
 

--- a/lib/providers/interaction_provider.dart
+++ b/lib/providers/interaction_provider.dart
@@ -90,7 +90,7 @@ class InteractionProvider with ChangeNotifier, StreamSubscriber {
     playable
       ..playCount = interaction.playCount
       ..liked = interaction.liked;
-    if (playable is Song) _downloadProvider.persistMetadataIfNeeded(playable);
+    _downloadProvider.persistMetadataIfNeeded(playable);
   }
 
   @override

--- a/lib/providers/interaction_provider.dart
+++ b/lib/providers/interaction_provider.dart
@@ -54,15 +54,27 @@ class InteractionProvider with ChangeNotifier, StreamSubscriber {
   Future<void> _like({required Song song}) async {
     song.liked = true;
     notifyListeners();
-    _downloadProvider.persistMetadataIfNeeded(song);
-    await post('interaction/like', data: {'song': song.id});
+    try {
+      await post('interaction/like', data: {'song': song.id});
+      _downloadProvider.persistMetadataIfNeeded(song);
+    } catch (e) {
+      song.liked = false;
+      notifyListeners();
+      rethrow;
+    }
   }
 
   Future<void> _unlike({required Song song}) async {
     song.liked = false;
     notifyListeners();
-    _downloadProvider.persistMetadataIfNeeded(song);
-    await post('interaction/like', data: {'song': song.id});
+    try {
+      await post('interaction/like', data: {'song': song.id});
+      _downloadProvider.persistMetadataIfNeeded(song);
+    } catch (e) {
+      song.liked = true;
+      notifyListeners();
+      rethrow;
+    }
   }
 
   Future<void> toggleLike({required Song song}) async {
@@ -78,6 +90,7 @@ class InteractionProvider with ChangeNotifier, StreamSubscriber {
     playable
       ..playCount = interaction.playCount
       ..liked = interaction.liked;
+    if (playable is Song) _downloadProvider.persistMetadataIfNeeded(playable);
   }
 
   @override

--- a/test/models/song_test.dart
+++ b/test/models/song_test.dart
@@ -114,6 +114,17 @@ void main() {
       expect(restored.year, 2020);
       expect(json['type'], 'songs');
     });
+
+    test('preserves liked status through round-trip', () {
+      final song = Song.fake();
+      song.liked = true;
+
+      final json = song.toJson();
+      final restored = Song.fromJson(json);
+
+      expect(json['liked'], isTrue);
+      expect(restored.liked, isTrue);
+    });
   });
 
   group('Song.matchKeywords', () {


### PR DESCRIPTION
## Summary
Three issues caused downloaded songs to appear as not favorited:

1. **`Song.toJson()` excluded `liked`** — downloaded songs always deserialized with `liked = false`
2. **Like toggle didn't persist to download storage** — toggling favorite on a downloaded song updated memory but not disk
3. **Download sync ignored `liked` changes** — the periodic sync didn't detect server-side favorite changes

## Changes
- Add `liked` field to `Song.toJson()`
- Add `persistMetadataIfNeeded()` to `DownloadProvider` (persists only if the song is downloaded)
- Call it from `InteractionProvider._like()` / `_unlike()`
- Include `liked` in `DownloadSyncProvider._songNeedsUpdate()` check

## Test plan
- [x] All 228 tests pass
- [x] New test verifies `liked` survives `toJson`/`fromJson` round-trip
- [x] Downloaded songs retain favorite status after app restart
- [x] Toggling favorite on a downloaded song persists to disk
- [x] Server-side favorite changes sync to downloaded copies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures song "liked" state is included in serialization and sync so likes remain consistent across devices.
  * Like/unlike actions now reliably persist local metadata when relevant and revert optimistically on failure.

* **Tests**
  * Added a unit test verifying the like/preference survives serialization round-trip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->