### PR TITLE
Fix master CI: PlayableActionSheet test overflows on stricter Flutter

### DIFF
--- a/test/ui/screens/playable_action_sheet_test.dart
+++ b/test/ui/screens/playable_action_sheet_test.dart
@@ -5,6 +5,7 @@ import 'package:app/providers/download_provider.dart';
 import 'package:app/providers/favorite_provider.dart';
 import 'package:app/ui/screens/playable_action_sheet.dart';
 import 'package:audio_service/audio_service.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -55,6 +56,10 @@ void main() {
         ],
         child: PlayableActionSheet(playable: song),
       ),
+      // The sheet is normally shown via showModalBottomSheet with
+      // isScrollControlled, which lets it overflow / scroll. When mounted
+      // bare, give it enough vertical room to lay out without overflow.
+      surfaceSize: const Size(414, 1024),
     );
   }
 


### PR DESCRIPTION
## Summary

The `PlayableActionSheet` test mounts the sheet at the iPhone X surface size (375×812). On the Flutter version pinned to CI's floating `stable` channel, the column overflows by ~2px and is reported as a render exception, failing master.

In production the sheet is shown via `showModalBottomSheet` with `isScrollControlled: true`, which sidesteps this — only the bare-mounted test trips it.

Bumps the test surface to 414×1024 so the layout has room.

## Test plan

- [x] \`flutter test test/ui/screens/playable_action_sheet_test.dart\` passes locally
- [ ] CI green on master after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test configuration for the action sheet widget to prevent layout overflow issues during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->