### PR TITLE
Make PlayableActionSheet actions list scroll on small screens

### DIFF
--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -91,10 +91,10 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                 ),
               ],
             ),
-            ListView(
-              physics: const NeverScrollableScrollPhysics(),
-              shrinkWrap: true,
-              children: <Widget>[
+            Flexible(
+              child: ListView(
+                shrinkWrap: true,
+                children: <Widget>[
                 if (!isCurrent)
                   PlayableActionButton(
                     text: 'Play Next',
@@ -269,6 +269,7 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                   hideSheetOnTap: false,
                 ),
               ],
+              ),
             ),
           ],
         ),

--- a/test/ui/screens/playable_action_sheet_test.dart
+++ b/test/ui/screens/playable_action_sheet_test.dart
@@ -43,6 +43,7 @@ void main() {
   Future<void> _mountSheet(
     WidgetTester tester, {
     required bool downloaded,
+    Size? surfaceSize,
   }) async {
     when(downloadProviderMock.has(playable: song)).thenReturn(downloaded);
 
@@ -56,10 +57,7 @@ void main() {
         ],
         child: PlayableActionSheet(playable: song),
       ),
-      // The sheet is normally shown via showModalBottomSheet with
-      // isScrollControlled, which lets it overflow / scroll. When mounted
-      // bare, give it enough vertical room to lay out without overflow.
-      surfaceSize: const Size(414, 1024),
+      surfaceSize: surfaceSize ?? const Size(375, 812),
     );
   }
 
@@ -112,6 +110,19 @@ void main() {
 
       verify(downloadProviderMock.removeForPlayable(song)).called(1);
       verifyNever(downloadProviderMock.download(playable: song));
+    },
+  );
+
+  testWidgets(
+    'lays out without overflow on small screens (iPhone SE)',
+    (tester) async {
+      await _mountSheet(
+        tester,
+        downloaded: true,
+        surfaceSize: const Size(320, 568),
+      );
+
+      expect(tester.takeException(), isNull);
     },
   );
 }


### PR DESCRIPTION
## Summary

The previous PR (#176) added a Download/Remove Download item to the song action sheet. On smaller screens (iPhone SE / X) the new item pushes total content past the available height, and because the inner \`ListView\` had \`NeverScrollableScrollPhysics()\` and \`shrinkWrap: true\`, the parent \`Column\` overflowed instead of letting the list scroll.

This wraps the \`ListView\` in \`Flexible\` and drops the never-scrollable physics. When content fits, the sheet looks identical (spaceBetween still pins the action list to the bottom). When content overflows, the action list scrolls within its allotment instead of throwing a render error.

## Test plan

- [x] New widget test mounts the sheet at iPhone SE size (320×568) and asserts no exception
- [x] Existing tests still pass (full suite green: 233/233)
- [ ] Smoke test on a small device or simulator after merge to confirm scrolling feels right

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved action sheet layout handling on smaller viewports to prevent overflow issues and better utilize available space.

* **Tests**
  * Added test coverage for action sheet behavior on small screens (320x568 resolution).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->