### PR TITLE
Reorganize PlayableActionSheet with quick-action row (Apple Music style)

### DIFF
--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -309,7 +309,7 @@ class _QuickAction extends StatelessWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Icon(icon, size: 26, color: color),
+                Icon(icon, color: color),
                 const SizedBox(height: 6),
                 Text(
                   label,

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -9,6 +9,7 @@ import 'package:app/ui/screens/info_sheet/info_sheet.dart';
 import 'package:app/ui/widgets/widgets.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:lucide_icons/lucide_icons.dart';
 import 'package:provider/provider.dart';
 
@@ -104,7 +105,7 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                     child: Row(
                       children: [
                         _QuickAction(
-                          label: 'Favorite',
+                          label: playable.liked ? 'Undo' : 'Favorite',
                           icon: Icon(playable.liked
                               ? CupertinoIcons.star_fill
                               : CupertinoIcons.star),
@@ -125,7 +126,7 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                         ),
                         const _QuickActionDivider(),
                         _QuickAction(
-                          label: _downloaded ? 'Downloaded' : 'Download',
+                          label: _downloaded ? 'Remove' : 'Download',
                           icon: _downloaded
                               ? const _CloudMinusIcon()
                               : const Icon(CupertinoIcons.cloud_download),
@@ -300,7 +301,12 @@ class _QuickAction extends StatelessWidget {
       child: Material(
         color: Colors.transparent,
         child: InkWell(
-          onTap: enabled ? onTap : null,
+          onTap: enabled
+              ? () {
+                  HapticFeedback.mediumImpact();
+                  onTap();
+                }
+              : null,
           child: Padding(
             padding: const EdgeInsets.symmetric(vertical: 12.0),
             child: Column(

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:app/app_state.dart';
+import 'package:app/constants/constants.dart';
 import 'package:app/enums.dart';
 import 'package:app/main.dart';
 import 'package:app/models/models.dart';
@@ -132,9 +133,10 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                                   radius: 11,
                                   color: Colors.white,
                                 )
-                              : Icon(_downloaded
-                                  ? LucideIcons.cloudOff
-                                  : CupertinoIcons.cloud_download),
+                              : (_downloaded
+                                  ? const _CloudMinusIcon()
+                                  : const Icon(
+                                      CupertinoIcons.cloud_download)),
                           enabled: !_downloading &&
                               (_downloaded || !inOfflineMode),
                           onTap: () async {
@@ -345,6 +347,46 @@ class _QuickAction extends StatelessWidget {
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _CloudMinusIcon extends StatelessWidget {
+  const _CloudMinusIcon({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final iconColor = IconTheme.of(context).color ?? Colors.white;
+    final size = IconTheme.of(context).size ?? 24.0;
+    final badgeSize = size * 0.55;
+
+    return SizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Icon(CupertinoIcons.cloud_fill, size: size, color: iconColor),
+          Positioned(
+            right: -2,
+            bottom: -2,
+            child: Container(
+              width: badgeSize,
+              height: badgeSize,
+              alignment: Alignment.center,
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                color: AppColors.red,
+              ),
+              child: Icon(
+                CupertinoIcons.minus,
+                size: badgeSize * 0.7,
+                color: Colors.white,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -126,7 +126,7 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                         ),
                         const PlayableQuickActionDivider(),
                         PlayableQuickAction(
-                          label: _downloaded ? 'Remove Download' : 'Download',
+                          label: _downloaded ? 'Undo Download' : 'Download',
                           icon: Icon(_downloaded
                               ? CupertinoIcons.xmark_circle_fill
                               : CupertinoIcons.cloud_download),

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -126,7 +126,7 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                         ),
                         const PlayableQuickActionDivider(),
                         PlayableQuickAction(
-                          label: _downloaded ? 'Undo Download' : 'Download',
+                          label: _downloaded ? 'Remove' : 'Download',
                           icon: Icon(_downloaded
                               ? CupertinoIcons.xmark_circle_fill
                               : CupertinoIcons.cloud_download),

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -126,7 +126,7 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                         label:
                             _downloaded ? 'Remove Download' : 'Download',
                         icon: _downloaded
-                            ? CupertinoIcons.checkmark_alt_circle_fill
+                            ? CupertinoIcons.trash
                             : CupertinoIcons.cloud_download,
                         enabled: _downloaded || !inOfflineMode,
                         onTap: () async {

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -123,7 +123,7 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                         },
                       ),
                       _QuickAction(
-                        label: _downloaded ? 'Delete' : 'Download',
+                        label: _downloaded ? 'Remove' : 'Download',
                         icon: _downloaded
                             ? CupertinoIcons.trash
                             : CupertinoIcons.cloud_download,

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -104,7 +104,8 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                     child: Row(
                       children: [
                         PlayableQuickAction(
-                          label: playable.liked ? 'Undo' : 'Favorite',
+                          label:
+                              playable.liked ? 'Undo Favorite' : 'Favorite',
                           icon: Icon(playable.liked
                               ? CupertinoIcons.star_fill
                               : CupertinoIcons.star),
@@ -125,10 +126,10 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                         ),
                         const PlayableQuickActionDivider(),
                         PlayableQuickAction(
-                          label: _downloaded ? 'Remove' : 'Download',
-                          icon: _downloaded
-                              ? const _CloudMinusIcon()
-                              : const Icon(CupertinoIcons.cloud_download),
+                          label: _downloaded ? 'Remove Download' : 'Download',
+                          icon: Icon(_downloaded
+                              ? CupertinoIcons.xmark_circle_fill
+                              : CupertinoIcons.cloud_download),
                           enabled: _downloaded || !inOfflineMode,
                           onTap: () {
                             Navigator.pop(context);
@@ -273,46 +274,6 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
             ),
           ],
         ),
-      ),
-    );
-  }
-}
-
-class _CloudMinusIcon extends StatelessWidget {
-  const _CloudMinusIcon({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    final iconColor = IconTheme.of(context).color ?? Colors.white;
-    final size = IconTheme.of(context).size ?? 24.0;
-    final badgeSize = size * 0.55;
-
-    return SizedBox(
-      width: size,
-      height: size,
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: [
-          Icon(CupertinoIcons.cloud_fill, size: size, color: iconColor),
-          Positioned(
-            right: -2,
-            bottom: -2,
-            child: Container(
-              width: badgeSize,
-              height: badgeSize,
-              alignment: Alignment.center,
-              decoration: const BoxDecoration(
-                shape: BoxShape.circle,
-                color: CupertinoColors.systemRed,
-              ),
-              child: Icon(
-                CupertinoIcons.minus,
-                size: badgeSize * 0.7,
-                color: Colors.white,
-              ),
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -126,7 +126,7 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                         label:
                             _downloaded ? 'Remove Download' : 'Download',
                         icon: _downloaded
-                            ? CupertinoIcons.cloud_download_fill
+                            ? CupertinoIcons.checkmark_alt_circle_fill
                             : CupertinoIcons.cloud_download,
                         enabled: _downloaded || !inOfflineMode,
                         onTap: () async {

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -25,6 +25,7 @@ class PlayableActionSheet extends StatefulWidget {
 class _PlayableActionSheetState extends State<PlayableActionSheet> {
   var _queued = false;
   var _downloaded = false;
+  var _downloading = false;
 
   initState() {
     super.initState();
@@ -105,9 +106,9 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                       children: [
                         _QuickAction(
                           label: 'Favorite',
-                          icon: playable.liked
+                          icon: Icon(playable.liked
                               ? CupertinoIcons.star_fill
-                              : CupertinoIcons.star,
+                              : CupertinoIcons.star),
                           enabled: !inOfflineMode,
                           onTap: () {
                             favoriteProvider.toggleOne(playable: playable);
@@ -117,7 +118,7 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                         const _QuickActionDivider(),
                         _QuickAction(
                           label: 'Details',
-                          icon: CupertinoIcons.text_quote,
+                          icon: const Icon(CupertinoIcons.text_quote),
                           onTap: () {
                             Navigator.pop(context);
                             showInfoSheet(context, playable: playable);
@@ -126,10 +127,16 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                         const _QuickActionDivider(),
                         _QuickAction(
                           label: _downloaded ? 'Downloaded' : 'Download',
-                          icon: _downloaded
-                              ? CupertinoIcons.trash
-                              : CupertinoIcons.cloud_download,
-                          enabled: _downloaded || !inOfflineMode,
+                          icon: _downloading
+                              ? const CupertinoActivityIndicator(
+                                  radius: 11,
+                                  color: Colors.white,
+                                )
+                              : Icon(_downloaded
+                                  ? LucideIcons.cloudOff
+                                  : CupertinoIcons.cloud_download),
+                          enabled: !_downloading &&
+                              (_downloaded || !inOfflineMode),
                           onTap: () async {
                             final downloadProvider =
                                 context.read<DownloadProvider>();
@@ -138,9 +145,22 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                                   .removeForPlayable(playable);
                               if (mounted) setState(() => _downloaded = false);
                             } else {
-                              await downloadProvider.download(
-                                  playable: playable);
-                              if (mounted) setState(() => _downloaded = true);
+                              setState(() => _downloading = true);
+                              try {
+                                await downloadProvider.download(
+                                    playable: playable);
+                                if (mounted) {
+                                  setState(() {
+                                    _downloaded = true;
+                                    _downloading = false;
+                                  });
+                                }
+                              } catch (_) {
+                                if (mounted) {
+                                  setState(() => _downloading = false);
+                                }
+                                rethrow;
+                              }
                             }
                           },
                         ),
@@ -283,7 +303,7 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
 
 class _QuickAction extends StatelessWidget {
   final String label;
-  final IconData icon;
+  final Widget icon;
   final VoidCallback onTap;
   final bool enabled;
 
@@ -309,7 +329,10 @@ class _QuickAction extends StatelessWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Icon(icon, color: color),
+                IconTheme(
+                  data: IconThemeData(color: color),
+                  child: icon,
+                ),
                 const SizedBox(height: 6),
                 Text(
                   label,

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -100,50 +100,52 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                     horizontal: 16.0,
                     vertical: 8.0,
                   ),
-                  child: Row(
-                    children: [
-                      _QuickAction(
-                        label: 'Favorite',
-                        icon: playable.liked
-                            ? CupertinoIcons.star_fill
-                            : CupertinoIcons.star,
-                        enabled: !inOfflineMode,
-                        onTap: () {
-                          favoriteProvider.toggleOne(playable: playable);
-                          setState(() {});
-                        },
-                      ),
-                      const SizedBox(width: 8),
-                      _QuickAction(
-                        label: 'Details',
-                        icon: CupertinoIcons.text_quote,
-                        onTap: () {
-                          Navigator.pop(context);
-                          showInfoSheet(context, playable: playable);
-                        },
-                      ),
-                      const SizedBox(width: 8),
-                      _QuickAction(
-                        label: _downloaded ? 'Downloaded' : 'Download',
-                        icon: _downloaded
-                            ? CupertinoIcons.trash
-                            : CupertinoIcons.cloud_download,
-                        enabled: _downloaded || !inOfflineMode,
-                        onTap: () async {
-                          final downloadProvider =
-                              context.read<DownloadProvider>();
-                          if (_downloaded) {
-                            await downloadProvider
-                                .removeForPlayable(playable);
-                            if (mounted) setState(() => _downloaded = false);
-                          } else {
-                            await downloadProvider.download(
-                                playable: playable);
-                            if (mounted) setState(() => _downloaded = true);
-                          }
-                        },
-                      ),
-                    ],
+                  child: IntrinsicHeight(
+                    child: Row(
+                      children: [
+                        _QuickAction(
+                          label: 'Favorite',
+                          icon: playable.liked
+                              ? CupertinoIcons.star_fill
+                              : CupertinoIcons.star,
+                          enabled: !inOfflineMode,
+                          onTap: () {
+                            favoriteProvider.toggleOne(playable: playable);
+                            setState(() {});
+                          },
+                        ),
+                        const _QuickActionDivider(),
+                        _QuickAction(
+                          label: 'Details',
+                          icon: CupertinoIcons.text_quote,
+                          onTap: () {
+                            Navigator.pop(context);
+                            showInfoSheet(context, playable: playable);
+                          },
+                        ),
+                        const _QuickActionDivider(),
+                        _QuickAction(
+                          label: _downloaded ? 'Downloaded' : 'Download',
+                          icon: _downloaded
+                              ? CupertinoIcons.trash
+                              : CupertinoIcons.cloud_download,
+                          enabled: _downloaded || !inOfflineMode,
+                          onTap: () async {
+                            final downloadProvider =
+                                context.read<DownloadProvider>();
+                            if (_downloaded) {
+                              await downloadProvider
+                                  .removeForPlayable(playable);
+                              if (mounted) setState(() => _downloaded = false);
+                            } else {
+                              await downloadProvider.download(
+                                  playable: playable);
+                              if (mounted) setState(() => _downloaded = true);
+                            }
+                          },
+                        ),
+                      ],
+                    ),
                   ),
                 ),
                 const Divider(indent: 16, endIndent: 16),
@@ -296,33 +298,54 @@ class _QuickAction extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final color = enabled ? Colors.white : Colors.white30;
-    final borderRadius = BorderRadius.circular(12);
 
     return Expanded(
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          borderRadius: borderRadius,
-          border: Border.all(color: Colors.white.withOpacity(0.2)),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: enabled ? onTap : null,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12.0),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(icon, size: 26, color: color),
+                const SizedBox(height: 6),
+                Text(
+                  label,
+                  textAlign: TextAlign.center,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(fontSize: 12, color: color),
+                ),
+              ],
+            ),
+          ),
         ),
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: enabled ? onTap : null,
-            borderRadius: borderRadius,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 12.0),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(icon, size: 26, color: color),
-                  const SizedBox(height: 6),
-                  Text(
-                    label,
-                    textAlign: TextAlign.center,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(fontSize: 12, color: color),
-                  ),
+      ),
+    );
+  }
+}
+
+class _QuickActionDivider extends StatelessWidget {
+  const _QuickActionDivider({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 1,
+      child: Center(
+        child: FractionallySizedBox(
+          heightFactor: 2 / 3,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  Colors.transparent,
+                  Colors.white.withValues(alpha: 0.4),
+                  Colors.transparent,
                 ],
               ),
             ),

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -337,7 +337,7 @@ class _QuickActionDivider extends StatelessWidget {
       child: Center(
         child: FractionallySizedBox(
           heightFactor: 2 / 3,
-          child: DecoratedBox(
+          child: Container(
             decoration: BoxDecoration(
               gradient: LinearGradient(
                 begin: Alignment.topCenter,

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -123,7 +123,7 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                         },
                       ),
                       _QuickAction(
-                        label: _downloaded ? 'Remove' : 'Download',
+                        label: _downloaded ? 'Downloaded' : 'Download',
                         icon: _downloaded
                             ? CupertinoIcons.trash
                             : CupertinoIcons.cloud_download,

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -25,7 +25,6 @@ class PlayableActionSheet extends StatefulWidget {
 class _PlayableActionSheetState extends State<PlayableActionSheet> {
   var _queued = false;
   var _downloaded = false;
-  var _downloading = false;
 
   initState() {
     super.initState();
@@ -111,8 +110,8 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                               : CupertinoIcons.star),
                           enabled: !inOfflineMode,
                           onTap: () {
+                            Navigator.pop(context);
                             favoriteProvider.toggleOne(playable: playable);
-                            setState(() {});
                           },
                         ),
                         const _QuickActionDivider(),
@@ -127,41 +126,18 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                         const _QuickActionDivider(),
                         _QuickAction(
                           label: _downloaded ? 'Downloaded' : 'Download',
-                          icon: _downloading
-                              ? const CupertinoActivityIndicator(
-                                  radius: 11,
-                                  color: Colors.white,
-                                )
-                              : (_downloaded
-                                  ? const _CloudMinusIcon()
-                                  : const Icon(
-                                      CupertinoIcons.cloud_download)),
-                          enabled: !_downloading &&
-                              (_downloaded || !inOfflineMode),
-                          onTap: () async {
+                          icon: _downloaded
+                              ? const _CloudMinusIcon()
+                              : const Icon(CupertinoIcons.cloud_download),
+                          enabled: _downloaded || !inOfflineMode,
+                          onTap: () {
+                            Navigator.pop(context);
                             final downloadProvider =
                                 context.read<DownloadProvider>();
                             if (_downloaded) {
-                              await downloadProvider
-                                  .removeForPlayable(playable);
-                              if (mounted) setState(() => _downloaded = false);
+                              downloadProvider.removeForPlayable(playable);
                             } else {
-                              setState(() => _downloading = true);
-                              try {
-                                await downloadProvider.download(
-                                    playable: playable);
-                                if (mounted) {
-                                  setState(() {
-                                    _downloaded = true;
-                                    _downloading = false;
-                                  });
-                                }
-                              } catch (_) {
-                                if (mounted) {
-                                  setState(() => _downloading = false);
-                                }
-                                rethrow;
-                              }
+                              downloadProvider.download(playable: playable);
                             }
                           },
                         ),

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -302,7 +302,7 @@ class _QuickAction extends StatelessWidget {
       child: DecoratedBox(
         decoration: BoxDecoration(
           borderRadius: borderRadius,
-          border: Border.all(color: Theme.of(context).dividerColor),
+          border: Border.all(color: Colors.white.withOpacity(0.2)),
         ),
         child: Material(
           color: Colors.transparent,

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -123,8 +123,7 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                         },
                       ),
                       _QuickAction(
-                        label:
-                            _downloaded ? 'Remove Download' : 'Download',
+                        label: _downloaded ? 'Delete' : 'Download',
                         icon: _downloaded
                             ? CupertinoIcons.trash
                             : CupertinoIcons.cloud_download,

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -101,7 +101,6 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                     vertical: 8.0,
                   ),
                   child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: [
                       _QuickAction(
                         label: 'Favorite',
@@ -114,6 +113,7 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                           setState(() {});
                         },
                       ),
+                      const SizedBox(width: 8),
                       _QuickAction(
                         label: 'Details',
                         icon: CupertinoIcons.text_quote,
@@ -122,6 +122,7 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                           showInfoSheet(context, playable: playable);
                         },
                       ),
+                      const SizedBox(width: 8),
                       _QuickAction(
                         label: _downloaded ? 'Downloaded' : 'Download',
                         icon: _downloaded
@@ -295,26 +296,36 @@ class _QuickAction extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final color = enabled ? Colors.white : Colors.white30;
+    final borderRadius = BorderRadius.circular(12);
 
     return Expanded(
-      child: InkWell(
-        onTap: enabled ? onTap : null,
-        borderRadius: BorderRadius.circular(12),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 8.0),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(icon, size: 28, color: color),
-              const SizedBox(height: 6),
-              Text(
-                label,
-                textAlign: TextAlign.center,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(fontSize: 12, color: color),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: borderRadius,
+          border: Border.all(color: Theme.of(context).dividerColor),
+        ),
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: enabled ? onTap : null,
+            borderRadius: borderRadius,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 12.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(icon, size: 26, color: color),
+                  const SizedBox(height: 6),
+                  Text(
+                    label,
+                    textAlign: TextAlign.center,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(fontSize: 12, color: color),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -9,7 +9,6 @@ import 'package:app/ui/screens/info_sheet/info_sheet.dart';
 import 'package:app/ui/widgets/widgets.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:lucide_icons/lucide_icons.dart';
 import 'package:provider/provider.dart';
 
@@ -104,7 +103,7 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                   child: IntrinsicHeight(
                     child: Row(
                       children: [
-                        _QuickAction(
+                        PlayableQuickAction(
                           label: playable.liked ? 'Undo' : 'Favorite',
                           icon: Icon(playable.liked
                               ? CupertinoIcons.star_fill
@@ -115,8 +114,8 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                             favoriteProvider.toggleOne(playable: playable);
                           },
                         ),
-                        const _QuickActionDivider(),
-                        _QuickAction(
+                        const PlayableQuickActionDivider(),
+                        PlayableQuickAction(
                           label: 'Details',
                           icon: const Icon(CupertinoIcons.text_quote),
                           onTap: () {
@@ -124,8 +123,8 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                             showInfoSheet(context, playable: playable);
                           },
                         ),
-                        const _QuickActionDivider(),
-                        _QuickAction(
+                        const PlayableQuickActionDivider(),
+                        PlayableQuickAction(
                           label: _downloaded ? 'Remove' : 'Download',
                           icon: _downloaded
                               ? const _CloudMinusIcon()
@@ -279,60 +278,6 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
   }
 }
 
-class _QuickAction extends StatelessWidget {
-  final String label;
-  final Widget icon;
-  final VoidCallback onTap;
-  final bool enabled;
-
-  const _QuickAction({
-    Key? key,
-    required this.label,
-    required this.icon,
-    required this.onTap,
-    this.enabled = true,
-  }) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    final color = enabled ? Colors.white : Colors.white30;
-
-    return Expanded(
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: enabled
-              ? () {
-                  HapticFeedback.mediumImpact();
-                  onTap();
-                }
-              : null,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 12.0),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                IconTheme(
-                  data: IconThemeData(color: color),
-                  child: icon,
-                ),
-                const SizedBox(height: 6),
-                Text(
-                  label,
-                  textAlign: TextAlign.center,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(fontSize: 12, color: color),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
 class _CloudMinusIcon extends StatelessWidget {
   const _CloudMinusIcon({Key? key}) : super(key: key);
 
@@ -368,31 +313,6 @@ class _CloudMinusIcon extends StatelessWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _QuickActionDivider extends StatelessWidget {
-  const _QuickActionDivider({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    final dividerColor =
-        DividerTheme.of(context).color ?? Theme.of(context).dividerColor;
-
-    return Container(
-      width: 1,
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [
-            Colors.transparent,
-            dividerColor,
-            Colors.transparent,
-          ],
-        ),
       ),
     );
   }

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -332,6 +332,9 @@ class _QuickActionDivider extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final dividerColor =
+        DividerTheme.of(context).color ?? Theme.of(context).dividerColor;
+
     return Container(
       width: 1,
       decoration: BoxDecoration(
@@ -340,7 +343,7 @@ class _QuickActionDivider extends StatelessWidget {
           end: Alignment.bottomCenter,
           colors: [
             Colors.transparent,
-            Colors.white.withValues(alpha: 0.4),
+            dividerColor,
             Colors.transparent,
           ],
         ),

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -332,24 +332,17 @@ class _QuickActionDivider extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
+    return Container(
       width: 1,
-      child: Center(
-        child: FractionallySizedBox(
-          heightFactor: 2 / 3,
-          child: Container(
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
-                colors: [
-                  Colors.transparent,
-                  Colors.white.withValues(alpha: 0.4),
-                  Colors.transparent,
-                ],
-              ),
-            ),
-          ),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            Colors.transparent,
+            Colors.white.withValues(alpha: 0.4),
+            Colors.transparent,
+          ],
         ),
       ),
     );

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -127,9 +127,9 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                         const PlayableQuickActionDivider(),
                         PlayableQuickAction(
                           label: _downloaded ? 'Remove' : 'Download',
-                          icon: Icon(_downloaded
-                              ? CupertinoIcons.xmark_circle_fill
-                              : CupertinoIcons.cloud_download),
+                          icon: _downloaded
+                              ? const _CloudMinusIcon()
+                              : const Icon(CupertinoIcons.cloud_download),
                           enabled: _downloaded || !inOfflineMode,
                           onTap: () {
                             Navigator.pop(context);
@@ -274,6 +274,46 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _CloudMinusIcon extends StatelessWidget {
+  const _CloudMinusIcon({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final iconColor = IconTheme.of(context).color ?? Colors.white;
+    final size = IconTheme.of(context).size ?? 24.0;
+    final badgeSize = size * 0.55;
+
+    return SizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Icon(CupertinoIcons.cloud_fill, size: size, color: iconColor),
+          Positioned(
+            right: -2,
+            bottom: -2,
+            child: Container(
+              width: badgeSize,
+              height: badgeSize,
+              alignment: Alignment.center,
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                color: CupertinoColors.systemRed,
+              ),
+              child: Icon(
+                CupertinoIcons.minus,
+                size: badgeSize * 0.7,
+                color: Colors.white,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -1,5 +1,4 @@
 import 'package:app/app_state.dart';
-import 'package:app/constants/constants.dart';
 import 'package:app/enums.dart';
 import 'package:app/main.dart';
 import 'package:app/models/models.dart';
@@ -377,7 +376,7 @@ class _CloudMinusIcon extends StatelessWidget {
               alignment: Alignment.center,
               decoration: const BoxDecoration(
                 shape: BoxShape.circle,
-                color: AppColors.red,
+                color: CupertinoColors.systemRed,
               ),
               child: Icon(
                 CupertinoIcons.minus,

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -5,6 +5,7 @@ import 'package:app/models/models.dart';
 import 'package:app/providers/providers.dart';
 import 'package:app/router.dart';
 import 'package:app/ui/screens/add_to_playlist.dart';
+import 'package:app/ui/screens/info_sheet/info_sheet.dart';
 import 'package:app/ui/widgets/widgets.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -91,186 +92,231 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                 ),
               ],
             ),
-            ListView(
-              physics: const NeverScrollableScrollPhysics(),
-              shrinkWrap: true,
-              children: <Widget>[
-                if (!isCurrent)
-                  PlayableActionButton(
-                    text: 'Play Next',
-                    icon: const Icon(
-                      CupertinoIcons.arrow_right_circle_fill,
-                      color: Colors.white30,
-                    ),
-                    onTap: () async {
-                      await audioHandler.queueAfterCurrent(playable);
-                      showOverlay(
-                        context,
-                        icon: CupertinoIcons.arrow_right_circle_fill,
-                        caption: 'Queued',
-                        message: 'To be played next.',
-                      );
-                    },
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16.0,
+                    vertical: 8.0,
                   ),
-                if (!isCurrent)
-                  PlayableActionButton(
-                    text: 'Play Last',
-                    icon: const Icon(
-                      CupertinoIcons.arrow_down_right_circle_fill,
-                      color: Colors.white30,
-                    ),
-                    onTap: () async {
-                      await audioHandler.queueToBottom(playable);
-                      showOverlay(
-                        context,
-                        icon: CupertinoIcons.arrow_down_right_circle_fill,
-                        caption: 'Queued',
-                        message: 'Queued to bottom.',
-                      );
-                    },
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: [
+                      _QuickAction(
+                        label: 'Favorite',
+                        icon: playable.liked
+                            ? CupertinoIcons.star_fill
+                            : CupertinoIcons.star,
+                        enabled: !inOfflineMode,
+                        onTap: () {
+                          favoriteProvider.toggleOne(playable: playable);
+                          setState(() {});
+                        },
+                      ),
+                      _QuickAction(
+                        label: 'Info',
+                        icon: CupertinoIcons.info,
+                        onTap: () {
+                          Navigator.pop(context);
+                          showInfoSheet(context, playable: playable);
+                        },
+                      ),
+                      _QuickAction(
+                        label:
+                            _downloaded ? 'Remove Download' : 'Download',
+                        icon: _downloaded
+                            ? CupertinoIcons.cloud_download_fill
+                            : CupertinoIcons.cloud_download,
+                        enabled: _downloaded || !inOfflineMode,
+                        onTap: () async {
+                          final downloadProvider =
+                              context.read<DownloadProvider>();
+                          if (_downloaded) {
+                            await downloadProvider
+                                .removeForPlayable(playable);
+                            if (mounted) setState(() => _downloaded = false);
+                          } else {
+                            await downloadProvider.download(
+                                playable: playable);
+                            if (mounted) setState(() => _downloaded = true);
+                          }
+                        },
+                      ),
+                    ],
                   ),
-                if (_queued)
-                  PlayableActionButton(
-                    text: 'Remove from Queue',
-                    icon: const Icon(
-                      CupertinoIcons.text_badge_minus,
-                      color: Colors.white30,
-                    ),
-                    onTap: () async {
-                      await audioHandler.removeFromQueue(playable);
-                      showOverlay(
-                        context,
-                        icon: CupertinoIcons.text_badge_minus,
-                        caption: 'Removed',
-                        message: 'Removed from queue.',
-                      );
-                    },
-                  ),
-                PlayableActionButton(
-                  enabled: _downloaded || !inOfflineMode,
-                  text: _downloaded ? 'Remove Download' : 'Download',
-                  icon: Icon(
-                    _downloaded
-                        ? CupertinoIcons.trash
-                        : CupertinoIcons.cloud_download_fill,
-                    color: Colors.white30,
-                  ),
-                  onTap: () async {
-                    final downloadProvider = context.read<DownloadProvider>();
-
-                    if (_downloaded) {
-                      await downloadProvider.removeForPlayable(playable);
-                      showOverlay(
-                        context,
-                        icon: CupertinoIcons.trash,
-                        caption: 'Removed',
-                        message: 'Removed from device.',
-                      );
-                    } else {
-                      showOverlay(
-                        context,
-                        icon: CupertinoIcons.cloud_download_fill,
-                        caption: 'Downloading',
-                        message: 'Saving for offline playback.',
-                      );
-                      await downloadProvider.download(playable: playable);
-                    }
-                  },
-                ),
-                PlayableActionButton(
-                  enabled: !inOfflineMode,
-                  text: playable.liked
-                      ? 'Remove as Favorite'
-                      : 'Mark as Favorite',
-                  icon: Icon(
-                    playable.liked
-                        ? CupertinoIcons.star_fill
-                        : CupertinoIcons.star,
-                    color: Colors.white30,
-                  ),
-                  onTap: () {
-                    showOverlay(
-                      context,
-                      caption: playable.liked ? 'Unliked' : 'Liked',
-                      message: playable.liked
-                          ? 'Removed from Favorites.'
-                          : 'Added to Favorites.',
-                      icon: playable.liked
-                          ? CupertinoIcons.star_slash
-                          : CupertinoIcons.star_fill,
-                    );
-                    favoriteProvider.toggleOne(playable: playable);
-                  },
                 ),
                 const Divider(indent: 16, endIndent: 16),
-                if (playable is Song)
-                  PlayableActionButton(
-                    enabled: !inOfflineMode,
-                    text: 'Go to Album',
-                    icon: const Icon(
-                      CupertinoIcons.music_albums_fill,
-                      color: Colors.white30,
+                ListView(
+                  physics: const NeverScrollableScrollPhysics(),
+                  shrinkWrap: true,
+                  children: <Widget>[
+                    if (!isCurrent)
+                      PlayableActionButton(
+                        text: 'Play Next',
+                        icon: const Icon(
+                          CupertinoIcons.arrow_right_circle_fill,
+                          color: Colors.white30,
+                        ),
+                        onTap: () async {
+                          await audioHandler.queueAfterCurrent(playable);
+                          showOverlay(
+                            context,
+                            icon: CupertinoIcons.arrow_right_circle_fill,
+                            caption: 'Queued',
+                            message: 'To be played next.',
+                          );
+                        },
+                      ),
+                    if (!isCurrent)
+                      PlayableActionButton(
+                        text: 'Play Last',
+                        icon: const Icon(
+                          CupertinoIcons.arrow_down_right_circle_fill,
+                          color: Colors.white30,
+                        ),
+                        onTap: () async {
+                          await audioHandler.queueToBottom(playable);
+                          showOverlay(
+                            context,
+                            icon: CupertinoIcons.arrow_down_right_circle_fill,
+                            caption: 'Queued',
+                            message: 'Queued to bottom.',
+                          );
+                        },
+                      ),
+                    if (_queued)
+                      PlayableActionButton(
+                        text: 'Remove from Queue',
+                        icon: const Icon(
+                          CupertinoIcons.text_badge_minus,
+                          color: Colors.white30,
+                        ),
+                        onTap: () async {
+                          await audioHandler.removeFromQueue(playable);
+                          showOverlay(
+                            context,
+                            icon: CupertinoIcons.text_badge_minus,
+                            caption: 'Removed',
+                            message: 'Removed from queue.',
+                          );
+                        },
+                      ),
+                    const Divider(indent: 16, endIndent: 16),
+                    if (playable is Song)
+                      PlayableActionButton(
+                        enabled: !inOfflineMode,
+                        text: 'Go to Album',
+                        icon: const Icon(
+                          CupertinoIcons.music_albums_fill,
+                          color: Colors.white30,
+                        ),
+                        onTap: () {
+                          Navigator.pop(context);
+                          AppRouter().gotoAlbumDetailsScreen(
+                            context,
+                            albumId: playable.albumId,
+                          );
+                        },
+                        hideSheetOnTap: false,
+                      ),
+                    if (playable is Episode)
+                      PlayableActionButton(
+                        enabled: !inOfflineMode,
+                        text: 'Go to Podcast',
+                        icon: const Icon(
+                          LucideIcons.podcast,
+                          color: Colors.white30,
+                        ),
+                        onTap: () {
+                          Navigator.pop(context);
+                          AppRouter().gotoPodcastDetailsScreen(
+                            context,
+                            podcastId: playable.podcastId,
+                          );
+                        },
+                        hideSheetOnTap: false,
+                      ),
+                    if (playable is Song)
+                      PlayableActionButton(
+                        enabled: !inOfflineMode,
+                        text: 'Go to Artist',
+                        icon: const Icon(
+                          CupertinoIcons.music_mic,
+                          color: Colors.white30,
+                        ),
+                        onTap: () {
+                          Navigator.pop(context);
+                          AppRouter().gotoArtistDetailsScreen(
+                            context,
+                            artistId: playable.artistId,
+                          );
+                        },
+                        hideSheetOnTap: false,
+                      ),
+                    const Divider(indent: 16, endIndent: 16),
+                    PlayableActionButton(
+                      enabled: !inOfflineMode,
+                      text: 'Add to a Playlist…',
+                      icon: const Icon(
+                        CupertinoIcons.text_badge_plus,
+                        color: Colors.white30,
+                      ),
+                      onTap: () {
+                        Navigator.pop(context);
+                        gotoAddToPlaylistScreen(context, playable: playable);
+                      },
+                      hideSheetOnTap: false,
                     ),
-                    onTap: () {
-                      Navigator.pop(context);
-                      AppRouter().gotoAlbumDetailsScreen(
-                        context,
-                        albumId: playable.albumId,
-                      );
-                    },
-                    hideSheetOnTap: false,
-                  ),
-                if (playable is Episode)
-                  PlayableActionButton(
-                    enabled: !inOfflineMode,
-                    text: 'Go to Podcast',
-                    icon: const Icon(
-                      LucideIcons.podcast,
-                      color: Colors.white30,
-                    ),
-                    onTap: () {
-                      Navigator.pop(context);
-                      AppRouter().gotoPodcastDetailsScreen(
-                        context,
-                        podcastId: playable.podcastId,
-                      );
-                    },
-                    hideSheetOnTap: false,
-                  ),
-                if (playable is Song)
-                  PlayableActionButton(
-                    enabled: !inOfflineMode,
-                    text: 'Go to Artist',
-                    icon: const Icon(
-                      CupertinoIcons.music_mic,
-                      color: Colors.white30,
-                    ),
-                    onTap: () {
-                      Navigator.pop(context);
-                      AppRouter().gotoArtistDetailsScreen(
-                        context,
-                        artistId: playable.artistId,
-                      );
-                    },
-                    hideSheetOnTap: false,
-                  ),
-                const Divider(indent: 16, endIndent: 16),
-                PlayableActionButton(
-                  enabled: !inOfflineMode,
-                  text: 'Add to a Playlist…',
-                  icon: const Icon(
-                    CupertinoIcons.text_badge_plus,
-                    color: Colors.white30,
-                  ),
-                  onTap: () {
-                    Navigator.pop(context);
-                    gotoAddToPlaylistScreen(context, playable: playable);
-                  },
-                  hideSheetOnTap: false,
+                  ],
                 ),
               ],
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _QuickAction extends StatelessWidget {
+  final String label;
+  final IconData icon;
+  final VoidCallback onTap;
+  final bool enabled;
+
+  const _QuickAction({
+    Key? key,
+    required this.label,
+    required this.icon,
+    required this.onTap,
+    this.enabled = true,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final color = enabled ? Colors.white : Colors.white30;
+
+    return Expanded(
+      child: InkWell(
+        onTap: enabled ? onTap : null,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 28, color: color),
+              const SizedBox(height: 6),
+              Text(
+                label,
+                textAlign: TextAlign.center,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(fontSize: 12, color: color),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/ui/screens/playable_action_sheet.dart
+++ b/lib/ui/screens/playable_action_sheet.dart
@@ -115,8 +115,8 @@ class _PlayableActionSheetState extends State<PlayableActionSheet> {
                         },
                       ),
                       _QuickAction(
-                        label: 'Info',
-                        icon: CupertinoIcons.info,
+                        label: 'Details',
+                        icon: CupertinoIcons.text_quote,
                         onTap: () {
                           Navigator.pop(context);
                           showInfoSheet(context, playable: playable);

--- a/lib/ui/widgets/playable_quick_action.dart
+++ b/lib/ui/widgets/playable_quick_action.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 

--- a/lib/ui/widgets/playable_quick_action.dart
+++ b/lib/ui/widgets/playable_quick_action.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// A vertically-stacked icon + label button used in the row of quick
+/// actions at the top of the [PlayableActionSheet].
+///
+/// Designed to sit inside an [IntrinsicHeight] [Row] so siblings share
+/// the same height. Triggers [HapticFeedback.mediumImpact] on tap to
+/// match the rest of the app's haptic conventions.
+class PlayableQuickAction extends StatelessWidget {
+  final String label;
+  final Widget icon;
+  final VoidCallback onTap;
+  final bool enabled;
+
+  const PlayableQuickAction({
+    Key? key,
+    required this.label,
+    required this.icon,
+    required this.onTap,
+    this.enabled = true,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final color = enabled ? Colors.white : Colors.white30;
+
+    return Expanded(
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: enabled
+              ? () {
+                  HapticFeedback.mediumImpact();
+                  onTap();
+                }
+              : null,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12.0),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconTheme(
+                  data: IconThemeData(color: color),
+                  child: icon,
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  label,
+                  textAlign: TextAlign.center,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(fontSize: 12, color: color),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A 1px-wide vertical divider with a transparent → divider-color →
+/// transparent gradient. Sized to fill the parent's height.
+class PlayableQuickActionDivider extends StatelessWidget {
+  const PlayableQuickActionDivider({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final dividerColor =
+        DividerTheme.of(context).color ?? Theme.of(context).dividerColor;
+
+    return Container(
+      width: 1,
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            Colors.transparent,
+            dividerColor,
+            Colors.transparent,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/widgets.dart
+++ b/lib/ui/widgets/widgets.dart
@@ -19,6 +19,7 @@ export 'now_playing/repeat_mode_button.dart';
 export 'now_playing/volume_slider.dart';
 export 'oops_box.dart';
 export 'playable_cache_icon.dart';
+export 'playable_quick_action.dart';
 export 'playable_list_header.dart';
 export 'playable_list_sort_button.dart';
 export 'playable_row.dart';

--- a/test/ui/screens/playable_action_sheet_test.dart
+++ b/test/ui/screens/playable_action_sheet_test.dart
@@ -64,7 +64,7 @@ void main() {
       await _mountSheet(tester, downloaded: false);
 
       expect(find.text('Download'), findsOneWidget);
-      expect(find.text('Remove Download'), findsNothing);
+      expect(find.text('Delete'), findsNothing);
     },
   );
 
@@ -73,7 +73,7 @@ void main() {
     (tester) async {
       await _mountSheet(tester, downloaded: true);
 
-      expect(find.text('Remove Download'), findsOneWidget);
+      expect(find.text('Delete'), findsOneWidget);
       expect(find.text('Download'), findsNothing);
     },
   );
@@ -101,7 +101,7 @@ void main() {
           .thenAnswer((_) async {});
 
       await _mountSheet(tester, downloaded: true);
-      await tester.tap(find.text('Remove Download'));
+      await tester.tap(find.text('Delete'));
       await tester.pump();
       await tester.pump(const Duration(seconds: 3));
 

--- a/test/ui/screens/playable_action_sheet_test.dart
+++ b/test/ui/screens/playable_action_sheet_test.dart
@@ -64,7 +64,7 @@ void main() {
       await _mountSheet(tester, downloaded: false);
 
       expect(find.text('Download'), findsOneWidget);
-      expect(find.text('Remove Download'), findsNothing);
+      expect(find.text('Undo Download'), findsNothing);
     },
   );
 
@@ -73,7 +73,7 @@ void main() {
     (tester) async {
       await _mountSheet(tester, downloaded: true);
 
-      expect(find.text('Remove Download'), findsOneWidget);
+      expect(find.text('Undo Download'), findsOneWidget);
       expect(find.text('Download'), findsNothing);
     },
   );
@@ -101,7 +101,7 @@ void main() {
           .thenAnswer((_) async {});
 
       await _mountSheet(tester, downloaded: true);
-      await tester.tap(find.text('Remove Download'));
+      await tester.tap(find.text('Undo Download'));
       await tester.pump();
       await tester.pump(const Duration(seconds: 3));
 

--- a/test/ui/screens/playable_action_sheet_test.dart
+++ b/test/ui/screens/playable_action_sheet_test.dart
@@ -64,7 +64,7 @@ void main() {
       await _mountSheet(tester, downloaded: false);
 
       expect(find.text('Download'), findsOneWidget);
-      expect(find.text('Remove'), findsNothing);
+      expect(find.text('Downloaded'), findsNothing);
     },
   );
 
@@ -73,7 +73,7 @@ void main() {
     (tester) async {
       await _mountSheet(tester, downloaded: true);
 
-      expect(find.text('Remove'), findsOneWidget);
+      expect(find.text('Downloaded'), findsOneWidget);
       expect(find.text('Download'), findsNothing);
     },
   );
@@ -101,7 +101,7 @@ void main() {
           .thenAnswer((_) async {});
 
       await _mountSheet(tester, downloaded: true);
-      await tester.tap(find.text('Remove'));
+      await tester.tap(find.text('Downloaded'));
       await tester.pump();
       await tester.pump(const Duration(seconds: 3));
 

--- a/test/ui/screens/playable_action_sheet_test.dart
+++ b/test/ui/screens/playable_action_sheet_test.dart
@@ -64,7 +64,7 @@ void main() {
       await _mountSheet(tester, downloaded: false);
 
       expect(find.text('Download'), findsOneWidget);
-      expect(find.text('Remove'), findsNothing);
+      expect(find.text('Remove Download'), findsNothing);
     },
   );
 
@@ -73,7 +73,7 @@ void main() {
     (tester) async {
       await _mountSheet(tester, downloaded: true);
 
-      expect(find.text('Remove'), findsOneWidget);
+      expect(find.text('Remove Download'), findsOneWidget);
       expect(find.text('Download'), findsNothing);
     },
   );
@@ -101,7 +101,7 @@ void main() {
           .thenAnswer((_) async {});
 
       await _mountSheet(tester, downloaded: true);
-      await tester.tap(find.text('Remove'));
+      await tester.tap(find.text('Remove Download'));
       await tester.pump();
       await tester.pump(const Duration(seconds: 3));
 

--- a/test/ui/screens/playable_action_sheet_test.dart
+++ b/test/ui/screens/playable_action_sheet_test.dart
@@ -26,11 +26,13 @@ void main() {
     audioHandlerMock = MockKoelAudioHandler();
     downloadProviderMock = MockDownloadProvider();
     favoriteProviderMock = MockFavoriteProvider();
-    song = Song.fake();
+    // Pin `liked` so tests that look up the unliked-state label
+    // ("Favorite") aren't flaky against Song.fake's random boolean.
+    song = Song.fake(liked: false);
 
     mediaItemSubject = BehaviorSubject<MediaItem?>.seeded(null);
     when(audioHandlerMock.mediaItem).thenAnswer((_) => mediaItemSubject);
-    when(audioHandlerMock.queued(song)).thenAnswer((_) async => false);
+    when(audioHandlerMock.queued(any)).thenAnswer((_) async => false);
 
     app.audioHandler = audioHandlerMock;
   });
@@ -64,17 +66,39 @@ void main() {
       await _mountSheet(tester, downloaded: false);
 
       expect(find.text('Download'), findsOneWidget);
-      expect(find.text('Undo Download'), findsNothing);
+      expect(find.text('Remove'), findsNothing);
     },
   );
 
   testWidgets(
-    'shows "Remove Download" when the song is downloaded',
+    'shows "Remove" when the song is downloaded',
     (tester) async {
       await _mountSheet(tester, downloaded: true);
 
-      expect(find.text('Undo Download'), findsOneWidget);
+      expect(find.text('Remove'), findsOneWidget);
       expect(find.text('Download'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'shows "Favorite" when the song is not liked',
+    (tester) async {
+      song = Song.fake(liked: false);
+      await _mountSheet(tester, downloaded: false);
+
+      expect(find.text('Favorite'), findsOneWidget);
+      expect(find.text('Undo Favorite'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'shows "Undo Favorite" when the song is liked',
+    (tester) async {
+      song = Song.fake(liked: true);
+      await _mountSheet(tester, downloaded: false);
+
+      expect(find.text('Undo Favorite'), findsOneWidget);
+      expect(find.text('Favorite'), findsNothing);
     },
   );
 
@@ -95,13 +119,13 @@ void main() {
   );
 
   testWidgets(
-    'tapping "Remove Download" delegates to DownloadProvider.removeForPlayable',
+    'tapping "Remove" delegates to DownloadProvider.removeForPlayable',
     (tester) async {
       when(downloadProviderMock.removeForPlayable(song))
           .thenAnswer((_) async {});
 
       await _mountSheet(tester, downloaded: true);
-      await tester.tap(find.text('Undo Download'));
+      await tester.tap(find.text('Remove'));
       await tester.pump();
       await tester.pump(const Duration(seconds: 3));
 

--- a/test/ui/screens/playable_action_sheet_test.dart
+++ b/test/ui/screens/playable_action_sheet_test.dart
@@ -64,7 +64,7 @@ void main() {
       await _mountSheet(tester, downloaded: false);
 
       expect(find.text('Download'), findsOneWidget);
-      expect(find.text('Downloaded'), findsNothing);
+      expect(find.text('Remove'), findsNothing);
     },
   );
 
@@ -73,7 +73,7 @@ void main() {
     (tester) async {
       await _mountSheet(tester, downloaded: true);
 
-      expect(find.text('Downloaded'), findsOneWidget);
+      expect(find.text('Remove'), findsOneWidget);
       expect(find.text('Download'), findsNothing);
     },
   );
@@ -101,7 +101,7 @@ void main() {
           .thenAnswer((_) async {});
 
       await _mountSheet(tester, downloaded: true);
-      await tester.tap(find.text('Downloaded'));
+      await tester.tap(find.text('Remove'));
       await tester.pump();
       await tester.pump(const Duration(seconds: 3));
 

--- a/test/ui/screens/playable_action_sheet_test.dart
+++ b/test/ui/screens/playable_action_sheet_test.dart
@@ -64,7 +64,7 @@ void main() {
       await _mountSheet(tester, downloaded: false);
 
       expect(find.text('Download'), findsOneWidget);
-      expect(find.text('Delete'), findsNothing);
+      expect(find.text('Remove'), findsNothing);
     },
   );
 
@@ -73,7 +73,7 @@ void main() {
     (tester) async {
       await _mountSheet(tester, downloaded: true);
 
-      expect(find.text('Delete'), findsOneWidget);
+      expect(find.text('Remove'), findsOneWidget);
       expect(find.text('Download'), findsNothing);
     },
   );
@@ -101,7 +101,7 @@ void main() {
           .thenAnswer((_) async {});
 
       await _mountSheet(tester, downloaded: true);
-      await tester.tap(find.text('Delete'));
+      await tester.tap(find.text('Remove'));
       await tester.pump();
       await tester.pump(const Duration(seconds: 3));
 

--- a/test/ui/screens/playable_action_sheet_test.dart
+++ b/test/ui/screens/playable_action_sheet_test.dart
@@ -5,7 +5,6 @@ import 'package:app/providers/download_provider.dart';
 import 'package:app/providers/favorite_provider.dart';
 import 'package:app/ui/screens/playable_action_sheet.dart';
 import 'package:audio_service/audio_service.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -56,10 +55,6 @@ void main() {
         ],
         child: PlayableActionSheet(playable: song),
       ),
-      // The sheet is normally shown via showModalBottomSheet with
-      // isScrollControlled, which lets it overflow / scroll. When mounted
-      // bare, give it enough vertical room to lay out without overflow.
-      surfaceSize: const Size(414, 1024),
     );
   }
 
@@ -112,6 +107,20 @@ void main() {
 
       verify(downloadProviderMock.removeForPlayable(song)).called(1);
       verifyNever(downloadProviderMock.download(playable: song));
+    },
+  );
+
+  testWidgets(
+    'tapping "Favorite" toggles via FavoriteProvider',
+    (tester) async {
+      when(favoriteProviderMock.toggleOne(playable: song))
+          .thenAnswer((_) async {});
+
+      await _mountSheet(tester, downloaded: false);
+      await tester.tap(find.text('Favorite'));
+      await tester.pump();
+
+      verify(favoriteProviderMock.toggleOne(playable: song)).called(1);
     },
   );
 }


### PR DESCRIPTION
## Summary

Reorganizes the song action sheet with an iOS-style quick-action row at the top — Favorite, Details, Download — that replaces the per-row Favorite and Download list rows. Each quick action runs `HapticFeedback.mediumImpact` on tap and dismisses the sheet before performing its work.

This also fixes the iPhone-X overflow that PR #176 introduced and PR #177 patched with a test surface bump: the new layout fits at the default 375×812, no in-sheet scrollable, so the modal sheet's drag-to-dismiss works on the entire surface (the original concern from PR #178 that I closed).

### Quick-action details

- **Favorite / Undo Favorite** — state-driven label and icon (filled vs outline star). Closes the sheet, then toggles via `FavoriteProvider`.
- **Details** — uses `CupertinoIcons.text_quote` to match the equivalent button on the Now Playing sheet. Closes the sheet, then opens the existing `InfoSheet`.
- **Download / Remove** — state-driven label. Cloud-download icon when not downloaded; cloud-fill with a `CupertinoColors.systemRed` minus badge when downloaded. Closes the sheet, then triggers `DownloadProvider.download` / `removeForPlayable`.

### Visual polish

- Hairline gradient dividers between the three quick actions: 1px wide, full row height, transparent → theme divider color → transparent vertical gradient (no per-button border or gap).
- Quick-action icons inherit the IconTheme size (24px) so they match the list-row icons below.

### Refactor

- Extracted `PlayableQuickAction` and `PlayableQuickActionDivider` into `lib/ui/widgets/playable_quick_action.dart`, exported from `widgets.dart`. The `_CloudMinusIcon` composer stays inline since it's specific to the download action.

## Test plan

- [x] Widget tests: label flips for both states (Favorite ↔ Undo Favorite, Download ↔ Remove) and tap-delegation to the correct provider for each. Full suite: 235/235 green.
- [x] `flutter analyze` clean on the touched files.
- [x] Sheet renders without overflow at the default test surface (375×812 / iPhone X).
- [ ] Smoke test on a device: tap each quick action, confirm haptic + sheet-dismiss + correct downstream behavior; confirm drag-to-dismiss works from anywhere on the sheet.