### PR TITLE
Fix typo in iOS/Runner/Info.plist, NSCameraUsageDescription

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -54,7 +54,7 @@
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>NSCameraUsageDescription</key>
-	<string>Require acces to camera to support login via QR code</string>
+	<string>Require access to camera to support login via QR code</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
         <string>https:</string>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a typo in the camera permission request message displayed to iOS users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->