### PR TITLE
Surface playlist Edit/Delete actions gated on koel 9.2.0 permissions

### DIFF
--- a/lib/models/playlist.dart
+++ b/lib/models/playlist.dart
@@ -10,6 +10,16 @@ class Playlist {
   String? cover;
   List<Playable> playables = [];
 
+  /// Whether the current user is allowed to edit this playlist.
+  /// Sourced from the koel >= 9.2.0 `permissions` object on the JSON
+  /// resource. Defaults to `false` when the server didn't include
+  /// permissions (older koel) so the UI hides the action by default.
+  bool canEdit;
+
+  /// Whether the current user is allowed to delete this playlist.
+  /// See [canEdit] for sourcing.
+  bool canDelete;
+
   Playlist({
     required this.id,
     required this.name,
@@ -17,6 +27,8 @@ class Playlist {
     this.folderId,
     this.description,
     this.cover,
+    this.canEdit = false,
+    this.canDelete = false,
   });
 
   bool get isEmpty => playables.length == 0;
@@ -24,6 +36,8 @@ class Playlist {
   bool get isStandard => !isSmart;
 
   factory Playlist.fromJson(Map<String, dynamic> json) {
+    final permissions = json['permissions'];
+
     return Playlist(
       id: json['id'],
       name: json['name'],
@@ -31,6 +45,8 @@ class Playlist {
       folderId: json['folder_id'],
       description: json['description'],
       cover: json['cover'],
+      canEdit: permissions is Map ? permissions['edit'] == true : false,
+      canDelete: permissions is Map ? permissions['delete'] == true : false,
     );
   }
 
@@ -52,6 +68,8 @@ class Playlist {
     String? folderId,
     String? description,
     String? cover,
+    bool canEdit = false,
+    bool canDelete = false,
   }) {
     Faker faker = Faker();
 
@@ -62,6 +80,8 @@ class Playlist {
       folderId: folderId,
       description: description,
       cover: cover,
+      canEdit: canEdit,
+      canDelete: canDelete,
     );
   }
 }

--- a/lib/ui/screens/edit_playlist_sheet.dart
+++ b/lib/ui/screens/edit_playlist_sheet.dart
@@ -1,0 +1,81 @@
+import 'package:app/models/models.dart';
+import 'package:app/providers/providers.dart';
+import 'package:app/ui/widgets/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+Future<void> showEditPlaylistDialog(
+  BuildContext context, {
+  required Playlist playlist,
+}) async {
+  final nameController = TextEditingController(text: playlist.name);
+  final descController =
+      TextEditingController(text: playlist.description ?? '');
+  final playlistProvider = context.read<PlaylistProvider>();
+  final folderProvider = context.read<PlaylistFolderProvider>();
+  final folders = folderProvider.folders;
+  String? selectedFolderId = playlist.folderId;
+
+  await showFormSheet(
+    context,
+    title: 'Edit Playlist',
+    submitLabel: 'Save',
+    canSubmit: () => nameController.text.trim().isNotEmpty,
+    onSubmit: () async {
+      final name = nameController.text.trim();
+      if (name.isEmpty) return;
+
+      try {
+        await playlistProvider.update(
+          playlist,
+          name: name,
+          description: descController.text.trim(),
+          folderId: selectedFolderId,
+        );
+        Navigator.pop(context);
+        showOverlay(context, caption: 'Playlist updated');
+      } catch (_) {
+        showOverlay(
+          context,
+          caption: 'Error',
+          message: 'Could not update playlist.',
+          icon: Icons.error_outline,
+        );
+      }
+    },
+    builder: (context, setState) {
+      return Column(
+        children: [
+          FormTextField(
+            controller: nameController,
+            placeholder: 'Playlist Name',
+            autofocus: true,
+            onChanged: (_) => setState(() {}),
+          ),
+          const SizedBox(height: 8),
+          FormTextField(
+            controller: descController,
+            placeholder: 'Description (optional)',
+            maxLines: 2,
+          ),
+          if (folders.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            FormDropdown<String?>(
+              value: selectedFolderId,
+              items: [null, ...folders.map((f) => f.id)],
+              labelBuilder: (id) {
+                if (id == null) return 'No folder';
+                final folder = folders
+                    .cast<dynamic>()
+                    .firstWhere((f) => f.id == id, orElse: () => null);
+                return folder?.name ?? 'No folder';
+              },
+              placeholder: 'No folder',
+              onChanged: (id) => setState(() => selectedFolderId = id),
+            ),
+          ],
+        ],
+      );
+    },
+  );
+}

--- a/lib/ui/screens/playlist_details.dart
+++ b/lib/ui/screens/playlist_details.dart
@@ -4,10 +4,8 @@ import 'package:app/extensions/extensions.dart';
 import 'package:app/models/models.dart';
 import 'package:app/providers/providers.dart';
 import 'package:app/ui/placeholders/placeholders.dart';
-import 'package:app/ui/screens/edit_playlist_sheet.dart';
 import 'package:app/ui/widgets/widgets.dart';
 import 'package:app/values/values.dart';
-import 'dart:ui';
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/cupertino.dart';
@@ -108,11 +106,6 @@ class _PlaylistDetailsScreen extends State<PlaylistDetailsScreen> {
                           AppState.set('playlist.sort', _sortConfig);
                         },
                       ),
-                      if (playlist.canEdit || playlist.canDelete)
-                        _PlaylistMenuButton(
-                          playlist: playlist,
-                          onUpdated: () => setState(() {}),
-                        ),
                     ],
                   ),
                   SliverToBoxAdapter(
@@ -175,92 +168,3 @@ void gotoDetailsScreen(BuildContext context, {required Playlist playlist}) {
   ));
 }
 
-class _PlaylistMenuButton extends StatelessWidget {
-  final Playlist playlist;
-  final VoidCallback onUpdated;
-
-  const _PlaylistMenuButton({
-    Key? key,
-    required this.playlist,
-    required this.onUpdated,
-  }) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return PopupMenuButton<String>(
-      icon: const Icon(CupertinoIcons.ellipsis_circle),
-      color: Colors.black87,
-      onSelected: (value) async {
-        switch (value) {
-          case 'edit':
-            await showEditPlaylistDialog(context, playlist: playlist);
-            // PlaylistProvider.update mutates the playlist in place;
-            // ask the screen to rebuild so the app bar title reflects
-            // the new name.
-            onUpdated();
-            break;
-          case 'delete':
-            final confirmed = await _confirmDelete(context);
-            if (!confirmed) return;
-            final provider = context.read<PlaylistProvider>();
-            await provider.remove(playlist);
-            if (context.mounted) {
-              Navigator.pop(context);
-              showOverlay(context, caption: 'Playlist deleted');
-            }
-            break;
-        }
-      },
-      itemBuilder: (_) => [
-        if (playlist.canEdit)
-          const PopupMenuItem(
-            value: 'edit',
-            child: Row(
-              children: [
-                Icon(CupertinoIcons.pencil, size: 18),
-                SizedBox(width: 12),
-                Text('Edit'),
-              ],
-            ),
-          ),
-        if (playlist.canDelete)
-          const PopupMenuItem(
-            value: 'delete',
-            child: Row(
-              children: [
-                Icon(CupertinoIcons.trash, size: 18, color: Colors.redAccent),
-                SizedBox(width: 12),
-                Text('Delete', style: TextStyle(color: Colors.redAccent)),
-              ],
-            ),
-          ),
-      ],
-    );
-  }
-
-  Future<bool> _confirmDelete(BuildContext context) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (_) => AlertDialog(
-        title: const Text('Delete playlist?'),
-        content: Text(
-          'Delete "${playlist.name}"? This cannot be undone.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: const Text(
-              'Delete',
-              style: TextStyle(color: Colors.redAccent),
-            ),
-          ),
-        ],
-      ),
-    );
-    return confirmed ?? false;
-  }
-}

--- a/lib/ui/screens/playlist_details.dart
+++ b/lib/ui/screens/playlist_details.dart
@@ -4,6 +4,7 @@ import 'package:app/extensions/extensions.dart';
 import 'package:app/models/models.dart';
 import 'package:app/providers/providers.dart';
 import 'package:app/ui/placeholders/placeholders.dart';
+import 'package:app/ui/screens/edit_playlist_sheet.dart';
 import 'package:app/ui/widgets/widgets.dart';
 import 'package:app/values/values.dart';
 import 'dart:ui';
@@ -107,6 +108,11 @@ class _PlaylistDetailsScreen extends State<PlaylistDetailsScreen> {
                           AppState.set('playlist.sort', _sortConfig);
                         },
                       ),
+                      if (playlist.canEdit || playlist.canDelete)
+                        _PlaylistMenuButton(
+                          playlist: playlist,
+                          onUpdated: () => setState(() {}),
+                        ),
                     ],
                   ),
                   SliverToBoxAdapter(
@@ -167,4 +173,94 @@ void gotoDetailsScreen(BuildContext context, {required Playlist playlist}) {
     ),
     builder: (_) => const PlaylistDetailsScreen(),
   ));
+}
+
+class _PlaylistMenuButton extends StatelessWidget {
+  final Playlist playlist;
+  final VoidCallback onUpdated;
+
+  const _PlaylistMenuButton({
+    Key? key,
+    required this.playlist,
+    required this.onUpdated,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<String>(
+      icon: const Icon(CupertinoIcons.ellipsis_circle),
+      color: Colors.black87,
+      onSelected: (value) async {
+        switch (value) {
+          case 'edit':
+            await showEditPlaylistDialog(context, playlist: playlist);
+            // PlaylistProvider.update mutates the playlist in place;
+            // ask the screen to rebuild so the app bar title reflects
+            // the new name.
+            onUpdated();
+            break;
+          case 'delete':
+            final confirmed = await _confirmDelete(context);
+            if (!confirmed) return;
+            final provider = context.read<PlaylistProvider>();
+            await provider.remove(playlist);
+            if (context.mounted) {
+              Navigator.pop(context);
+              showOverlay(context, caption: 'Playlist deleted');
+            }
+            break;
+        }
+      },
+      itemBuilder: (_) => [
+        if (playlist.canEdit)
+          const PopupMenuItem(
+            value: 'edit',
+            child: Row(
+              children: [
+                Icon(CupertinoIcons.pencil, size: 18),
+                SizedBox(width: 12),
+                Text('Edit'),
+              ],
+            ),
+          ),
+        if (playlist.canDelete)
+          const PopupMenuItem(
+            value: 'delete',
+            child: Row(
+              children: [
+                Icon(CupertinoIcons.trash, size: 18, color: Colors.redAccent),
+                SizedBox(width: 12),
+                Text('Delete', style: TextStyle(color: Colors.redAccent)),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+
+  Future<bool> _confirmDelete(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Delete playlist?'),
+        content: Text(
+          'Delete "${playlist.name}"? This cannot be undone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text(
+              'Delete',
+              style: TextStyle(color: Colors.redAccent),
+            ),
+          ),
+        ],
+      ),
+    );
+    return confirmed ?? false;
+  }
 }

--- a/lib/ui/screens/playlists.dart
+++ b/lib/ui/screens/playlists.dart
@@ -181,38 +181,42 @@ class _PlaylistsScreenState extends State<PlaylistsScreen> {
             child: CupertinoSliverNavigationBar(
               backgroundColor: AppColors.staticScreenHeaderBackground,
               largeTitle: const LargeTitle(text: 'Playlists'),
-              trailing: PopupMenuButton<String>(
-                icon: const Icon(CupertinoIcons.add_circled),
-                offset: const Offset(-12, 48),
-                onSelected: (value) {
-                  if (value == 'playlist') {
-                    widget.router.showCreatePlaylistSheet(context);
-                  } else if (value == 'folder') {
-                    widget.router.showCreatePlaylistFolderSheet(context);
-                  }
-                },
-                itemBuilder: (_) => [
-                  const PopupMenuItem(
-                    value: 'playlist',
-                    child: Row(
-                      children: [
-                        Icon(CupertinoIcons.music_note_list, size: 18),
-                        SizedBox(width: 12),
-                        Text('New Playlist'),
+              trailing: Builder(
+                builder: (buttonContext) => IconButton(
+                  icon: const Icon(CupertinoIcons.add_circled),
+                  onPressed: () async {
+                    final box =
+                        buttonContext.findRenderObject() as RenderBox?;
+                    final origin = box == null
+                        ? Offset.zero
+                        : box.localToGlobal(Offset.zero) +
+                            Offset(0, box.size.height);
+
+                    final selected = await showFrostedContextMenu<String>(
+                      context: buttonContext,
+                      position: origin,
+                      items: const [
+                        FrostedMenuItem(
+                          value: 'playlist',
+                          icon: CupertinoIcons.music_note_list,
+                          label: 'New Playlist',
+                        ),
+                        FrostedMenuItem(
+                          value: 'folder',
+                          icon: CupertinoIcons.folder,
+                          label: 'New Folder',
+                        ),
                       ],
-                    ),
-                  ),
-                  const PopupMenuItem(
-                    value: 'folder',
-                    child: Row(
-                      children: [
-                        Icon(CupertinoIcons.folder, size: 18),
-                        SizedBox(width: 12),
-                        Text('New Folder'),
-                      ],
-                    ),
-                  ),
-                ],
+                    );
+                    if (!buttonContext.mounted) return;
+                    if (selected == 'playlist') {
+                      widget.router.showCreatePlaylistSheet(buttonContext);
+                    } else if (selected == 'folder') {
+                      widget.router
+                          .showCreatePlaylistFolderSheet(buttonContext);
+                    }
+                  },
+                ),
               ),
             ),
           ),

--- a/lib/ui/screens/screens.dart
+++ b/lib/ui/screens/screens.dart
@@ -8,6 +8,7 @@ export 'create_playlist_folder_sheet.dart';
 export 'create_playlist_sheet.dart';
 export 'data_loading.dart';
 export 'downloaded.dart';
+export 'edit_playlist_sheet.dart';
 export 'favorites.dart';
 export 'genre_details.dart';
 export 'genres.dart';

--- a/lib/ui/widgets/frosted_context_menu.dart
+++ b/lib/ui/widgets/frosted_context_menu.dart
@@ -1,0 +1,191 @@
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// One row in a [showFrostedContextMenu] popup.
+class FrostedMenuItem<T> {
+  /// The value returned from [showFrostedContextMenu] when this row is
+  /// tapped.
+  final T value;
+
+  /// The visible label text.
+  final String label;
+
+  /// An optional leading icon. When `null`, the row renders label-only.
+  final IconData? icon;
+
+  /// When `true`, the row renders in `CupertinoColors.systemRed` to
+  /// signal a destructive action (e.g., Delete).
+  final bool destructive;
+
+  const FrostedMenuItem({
+    required this.value,
+    required this.label,
+    this.icon,
+    this.destructive = false,
+  });
+}
+
+/// Shows a translucent dark menu at [position] (global screen coords).
+///
+/// Backed by an [OverlayEntry] (not a route) so that the inner
+/// [BackdropFilter] can blur the content underneath — a route-based
+/// approach can introduce compositing isolation that disables the blur.
+///
+/// Returns the [FrostedMenuItem.value] of the tapped row, or `null` if
+/// the user dismissed by tapping outside.
+Future<T?> showFrostedContextMenu<T>({
+  required BuildContext context,
+  required Offset position,
+  required List<FrostedMenuItem<T>> items,
+}) {
+  final completer = Completer<T?>();
+  late OverlayEntry entry;
+
+  void close(T? value) {
+    if (!completer.isCompleted) completer.complete(value);
+    entry.remove();
+  }
+
+  entry = OverlayEntry(
+    builder: (_) => _FrostedContextMenu<T>(
+      anchor: position,
+      items: items,
+      onSelect: (value) => close(value),
+      onDismiss: () => close(null),
+    ),
+  );
+
+  Overlay.of(context).insert(entry);
+  return completer.future;
+}
+
+class _FrostedContextMenu<T> extends StatelessWidget {
+  final Offset anchor;
+  final List<FrostedMenuItem<T>> items;
+  final ValueChanged<T> onSelect;
+  final VoidCallback onDismiss;
+
+  const _FrostedContextMenu({
+    Key? key,
+    required this.anchor,
+    required this.items,
+    required this.onSelect,
+    required this.onDismiss,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final dividerColor =
+        DividerTheme.of(context).color ?? Theme.of(context).dividerColor;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // Estimate to keep the menu inside the viewport. The menu's
+        // actual width is decided by IntrinsicWidth + minWidth.
+        const estimatedWidth = 180.0;
+        final estimatedHeight = items.length * 36.0 + 12;
+
+        var left = anchor.dx;
+        var top = anchor.dy;
+        if (left + estimatedWidth > constraints.maxWidth) {
+          left = constraints.maxWidth - estimatedWidth - 8;
+        }
+        if (top + estimatedHeight > constraints.maxHeight) {
+          top = constraints.maxHeight - estimatedHeight - 8;
+        }
+        if (left < 8) left = 8;
+        if (top < 8) top = 8;
+
+        return Stack(
+          children: [
+            Positioned.fill(
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: onDismiss,
+              ),
+            ),
+            Positioned(
+              left: left,
+              top: top,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(10),
+                  border: Border.all(color: dividerColor),
+                ),
+                position: DecorationPosition.foreground,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(10),
+                  child: BackdropFilter(
+                    filter: ImageFilter.blur(sigmaX: 16, sigmaY: 16),
+                    child: ColoredBox(
+                      color: Colors.black.withValues(alpha: 0.25),
+                      child: Material(
+                        type: MaterialType.transparency,
+                        child: IntrinsicWidth(
+                          child: ConstrainedBox(
+                            constraints: const BoxConstraints(minWidth: 144),
+                            child: Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(vertical: 6),
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                crossAxisAlignment:
+                                    CrossAxisAlignment.stretch,
+                                children: items
+                                    .map((item) => _FrostedMenuRow<T>(
+                                          item: item,
+                                          onTap: () => onSelect(item.value),
+                                        ))
+                                    .toList(),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _FrostedMenuRow<T> extends StatelessWidget {
+  final FrostedMenuItem<T> item;
+  final VoidCallback onTap;
+
+  const _FrostedMenuRow({
+    Key? key,
+    required this.item,
+    required this.onTap,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final color =
+        item.destructive ? CupertinoColors.systemRed : Colors.white;
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 9),
+        child: Row(
+          children: [
+            if (item.icon != null) ...[
+              Icon(item.icon, size: 16, color: color),
+              const SizedBox(width: 8),
+            ],
+            Text(item.label, style: TextStyle(color: color, fontSize: 14)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/playlist_row.dart
+++ b/lib/ui/widgets/playlist_row.dart
@@ -2,8 +2,10 @@ import 'package:app/mixins/stream_subscriber.dart';
 import 'package:app/models/models.dart';
 import 'package:app/providers/providers.dart';
 import 'package:app/ui/screens/screens.dart';
+import 'package:app/ui/widgets/widgets.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 class PlaylistRow extends StatefulWidget {
@@ -21,6 +23,8 @@ class _PlaylistRowState extends State<PlaylistRow> with StreamSubscriber {
   late final PlaylistProvider playlistProvider;
   late Playlist _playlist;
 
+  Offset? _lastTapPosition;
+
   @override
   initState() {
     super.initState();
@@ -30,17 +34,85 @@ class _PlaylistRowState extends State<PlaylistRow> with StreamSubscriber {
 
   void _defaultOnTap() => gotoDetailsScreen(context, playlist: _playlist);
 
+  Future<void> _onLongPress() async {
+    final canEdit = _playlist.canEdit;
+    final canDelete = _playlist.canDelete;
+    if (!canEdit && !canDelete) return;
+
+    HapticFeedback.mediumImpact();
+
+    final selected = await showFrostedContextMenu<String>(
+      context: context,
+      position: _lastTapPosition ?? Offset.zero,
+      items: [
+        if (canEdit)
+          const FrostedMenuItem(
+            value: 'edit',
+            icon: CupertinoIcons.pencil,
+            label: 'Edit',
+          ),
+        if (canDelete)
+          const FrostedMenuItem(
+            value: 'delete',
+            icon: CupertinoIcons.trash,
+            label: 'Delete',
+            destructive: true,
+          ),
+      ],
+    );
+
+    if (!mounted) return;
+
+    switch (selected) {
+      case 'edit':
+        await showEditPlaylistDialog(context, playlist: _playlist);
+        if (mounted) setState(() {});
+        break;
+      case 'delete':
+        await _confirmAndDelete();
+        break;
+    }
+  }
+
+  Future<void> _confirmAndDelete() async {
+    final confirmed = await showCupertinoDialog<bool>(
+      context: context,
+      builder: (dialogContext) => CupertinoAlertDialog(
+        title: const Text('Delete playlist?'),
+        content: Text('Delete "${_playlist.name}"? This cannot be undone.'),
+        actions: [
+          CupertinoDialogAction(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Cancel'),
+          ),
+          CupertinoDialogAction(
+            isDestructiveAction: true,
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    await playlistProvider.remove(_playlist);
+    if (mounted) showOverlay(context, caption: 'Playlist deleted');
+  }
+
   @override
   Widget build(BuildContext context) {
-    final subtitle = _playlist.isSmart ? 'Smart playlist' : 'Standard playlist';
-
     return InkWell(
       onTap: widget.onTap ?? _defaultOnTap,
+      onTapDown: (details) => _lastTapPosition = details.globalPosition,
+      onLongPress: _onLongPress,
       child: ListTile(
         shape: Border(bottom: Divider.createBorderSide(context)),
         leading: PlaylistThumbnail(playlist: _playlist),
         title: Text(_playlist.name, overflow: TextOverflow.ellipsis),
-        subtitle: Text(subtitle),
+        subtitle: Text(
+          _playlist.isSmart ? 'Smart playlist' : 'Standard playlist',
+        ),
       ),
     );
   }

--- a/lib/ui/widgets/profile_avatar.dart
+++ b/lib/ui/widgets/profile_avatar.dart
@@ -1,6 +1,7 @@
 import 'package:app/main.dart';
 import 'package:app/providers/providers.dart';
 import 'package:app/ui/screens/screens.dart';
+import 'package:app/ui/widgets/widgets.dart';
 import 'package:app/utils/route_state.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -46,32 +47,47 @@ class ProfileAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final downloads = context.read<DownloadProvider>();
+    return Builder(
+      builder: (buttonContext) => IconButton(
+        icon: const Icon(CupertinoIcons.person_alt_circle, size: 24),
+        onPressed: () async {
+          final box = buttonContext.findRenderObject() as RenderBox?;
+          final origin = box == null
+              ? Offset.zero
+              : box.localToGlobal(Offset.zero) + Offset(0, box.size.height);
 
-    return PopupMenuButton<ProfileAvatarMenuItems>(
-      onSelected: (item) {
-        switch (item) {
-          case ProfileAvatarMenuItems.clearDownloads:
-            downloads.clear();
-            break;
-          case ProfileAvatarMenuItems.logout:
-            logout(context);
-            break;
-        }
-      },
-      child: const Icon(CupertinoIcons.person_alt_circle, size: 24),
-      offset: const Offset(0, 32),
-      itemBuilder: (_) => [
-        const PopupMenuItem(
-          value: ProfileAvatarMenuItems.clearDownloads,
-          child: Text('Clear downloads'),
-        ),
-        const PopupMenuDivider(height: .5),
-        const PopupMenuItem(
-          value: ProfileAvatarMenuItems.logout,
-          child: Text('Log out'),
-        ),
-      ],
+          final selected =
+              await showFrostedContextMenu<ProfileAvatarMenuItems>(
+            context: buttonContext,
+            position: origin,
+            items: const [
+              FrostedMenuItem(
+                value: ProfileAvatarMenuItems.clearDownloads,
+                icon: CupertinoIcons.cloud_download,
+                label: 'Clear downloads',
+              ),
+              FrostedMenuItem(
+                value: ProfileAvatarMenuItems.logout,
+                icon: CupertinoIcons.square_arrow_right,
+                label: 'Log out',
+                destructive: true,
+              ),
+            ],
+          );
+          if (!buttonContext.mounted) return;
+
+          switch (selected) {
+            case ProfileAvatarMenuItems.clearDownloads:
+              buttonContext.read<DownloadProvider>().clear();
+              break;
+            case ProfileAvatarMenuItems.logout:
+              logout(buttonContext);
+              break;
+            case null:
+              break;
+          }
+        },
+      ),
     );
   }
 }

--- a/lib/ui/widgets/widgets.dart
+++ b/lib/ui/widgets/widgets.dart
@@ -6,6 +6,7 @@ export 'artist_card.dart';
 export 'bottom_space.dart';
 export 'decorated_image_box.dart';
 export 'form_sheet.dart';
+export 'frosted_context_menu.dart';
 export 'frosted_glass_background.dart';
 export 'gradient_decorated_container.dart';
 export 'horizontal_card_scroller.dart';

--- a/test/models/playlist_test.dart
+++ b/test/models/playlist_test.dart
@@ -70,6 +70,62 @@ void main() {
       final playlist = Playlist.fromJson(json);
       expect(playlist.folderId, isNull);
     });
+
+    test('parses canEdit and canDelete from permissions', () {
+      final json = {
+        'id': 'playlist-perm',
+        'name': 'Perm',
+        'is_smart': false,
+        'permissions': {'edit': true, 'delete': true},
+      };
+
+      final playlist = Playlist.fromJson(json);
+      expect(playlist.canEdit, isTrue);
+      expect(playlist.canDelete, isTrue);
+    });
+
+    test('honors per-action permission flags independently', () {
+      final json = {
+        'id': 'playlist-perm-mixed',
+        'name': 'Mixed',
+        'is_smart': false,
+        'permissions': {'edit': true, 'delete': false},
+      };
+
+      final playlist = Playlist.fromJson(json);
+      expect(playlist.canEdit, isTrue);
+      expect(playlist.canDelete, isFalse);
+    });
+
+    test('defaults canEdit/canDelete to false when permissions is absent',
+        () {
+      // Older koel (< 9.2.0) doesn't include the permissions key. The
+      // client should still parse the resource and treat both actions
+      // as not permitted so the UI hides them.
+      final json = {
+        'id': 'playlist-old',
+        'name': 'Old Server',
+        'is_smart': false,
+      };
+
+      final playlist = Playlist.fromJson(json);
+      expect(playlist.canEdit, isFalse);
+      expect(playlist.canDelete, isFalse);
+    });
+
+    test('defaults to false when permissions keys are missing or non-bool',
+        () {
+      final json = {
+        'id': 'playlist-partial',
+        'name': 'Partial',
+        'is_smart': false,
+        'permissions': {'edit': null},
+      };
+
+      final playlist = Playlist.fromJson(json);
+      expect(playlist.canEdit, isFalse);
+      expect(playlist.canDelete, isFalse);
+    });
   });
 
   group('Playlist properties', () {

--- a/test/ui/widgets/playlist_row_test.dart
+++ b/test/ui/widgets/playlist_row_test.dart
@@ -55,4 +55,85 @@ void main() {
     expect(find.text('Smart Mix'), findsOneWidget);
     expect(find.text('Smart playlist'), findsOneWidget);
   });
+
+  group('long-press context menu', () {
+    testWidgets(
+      'shows Edit when canEdit',
+      (WidgetTester tester) async {
+        playlist = Playlist.fake(name: 'Editable', canEdit: true);
+
+        await tester.pumpAppWidget(
+          ChangeNotifierProvider<PlaylistProvider>.value(
+            value: playlistProviderMock,
+            child: PlaylistRow(playlist: playlist),
+          ),
+        );
+
+        await tester.longPress(find.byType(PlaylistRow));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Edit'), findsOneWidget);
+        expect(find.text('Delete'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'shows Delete when canDelete',
+      (WidgetTester tester) async {
+        playlist = Playlist.fake(name: 'Deletable', canDelete: true);
+
+        await tester.pumpAppWidget(
+          ChangeNotifierProvider<PlaylistProvider>.value(
+            value: playlistProviderMock,
+            child: PlaylistRow(playlist: playlist),
+          ),
+        );
+
+        await tester.longPress(find.byType(PlaylistRow));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Delete'), findsOneWidget);
+        expect(find.text('Edit'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'shows both actions when both permissions are granted',
+      (WidgetTester tester) async {
+        playlist = Playlist.fake(canEdit: true, canDelete: true);
+
+        await tester.pumpAppWidget(
+          ChangeNotifierProvider<PlaylistProvider>.value(
+            value: playlistProviderMock,
+            child: PlaylistRow(playlist: playlist),
+          ),
+        );
+
+        await tester.longPress(find.byType(PlaylistRow));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Edit'), findsOneWidget);
+        expect(find.text('Delete'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'no menu when neither permission is granted',
+      (WidgetTester tester) async {
+        // Default Playlist.fake: canEdit=false, canDelete=false.
+        await tester.pumpAppWidget(
+          ChangeNotifierProvider<PlaylistProvider>.value(
+            value: playlistProviderMock,
+            child: PlaylistRow(playlist: playlist),
+          ),
+        );
+
+        await tester.longPress(find.byType(PlaylistRow));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Edit'), findsNothing);
+        expect(find.text('Delete'), findsNothing);
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Summary

Koel 9.2.0 ships an authorization-aware `permissions` object on resource JSON, e.g.:

```php
'permissions' => $this->unless($embedding, fn () => [
    'edit'   => $user->can('edit', $this->playlist),
    'delete' => $user->can('delete', $this->playlist),
]),
```

This wires the playlist side of that into the app, with the actions surfaced via a long-press context menu and the supporting widget extracted for reuse.

### Model

- `Playlist.fromJson` parses `permissions.edit` / `permissions.delete` into new `canEdit` / `canDelete` flags. When the `permissions` key is absent (older koel < 9.2.0) or its inner values aren't booleans, both flags default to `false`, so the UI silently hides the actions on older servers.

### Edit / Delete UI

- `PlaylistRow` exposes the actions on **long-press**. The menu only shows the rows the user is allowed to use (Edit / Delete / both). If neither is allowed, long-press is a no-op.
- **Edit** opens a new `showEditPlaylistDialog` (modeled on the existing create-playlist sheet), prefilled with the current name / description / folder, and calls `PlaylistProvider.update`.
- **Delete** confirms via `CupertinoAlertDialog`, then calls `PlaylistProvider.remove` and shows a "Playlist deleted" overlay. The provider already removes the entry from its in-memory list, so the row drops out of the parent `Consumer`.
- The `PlaylistDetailsScreen` app bar is unchanged — actions live on the row, not on the details screen.

### Reusable `FrostedContextMenu`

Extracted to `lib/ui/widgets/frosted_context_menu.dart` and exported from `widgets.dart`:

```dart
showFrostedContextMenu<T>({
  required BuildContext context,
  required Offset position,
  required List<FrostedMenuItem<T>> items,
});
```

- Translucent dark popup (`Colors.black` @ 25%) with a real `BackdropFilter(sigma: 16)` blur, rounded corners, and a 1-px border in the theme divider color.
- Lives in an `OverlayEntry` rather than a route — a route-based approach introduces compositing isolation that disables the blur.
- Tap-outside dismisses; selecting an item completes the awaited `Future<T?>`.
- Items support an optional icon, a label, and a `destructive` flag (renders in `CupertinoColors.systemRed`).

Two existing menus converted to use it:

- **Playlists** "+" button — New Playlist / New Folder.
- **ProfileAvatar** — Clear downloads / Log out (logout marked destructive).

Sort menus (`PlayableListSortButton`, podcasts) keep `PopupMenuButton` for now since they have selected-state + sort-direction semantics this menu doesn't model yet.

## Test plan

- [x] `flutter test` — full suite green (243/243)
- [x] Model tests cover all four permissions parsing branches: present-true, mixed flags, missing key (older koel), null/non-bool values
- [x] `PlaylistRow` widget tests cover the four long-press permission combinations (Edit only / Delete only / both / neither)
- [x] `flutter analyze` clean on touched files
- [ ] Smoke test against a 9.2.0 backend with two users (owner / non-owner) on the same playlist; confirm long-press surfaces the menu for the owner and is a no-op for the other
- [ ] Smoke test against an older backend (no `permissions` key) — long-press must be a no-op
- [ ] Smoke test the converted menus (Playlists "+" button, profile avatar) — same actions, new look