### PR TITLE
Refresh playlists after edit when folder changes

### DIFF
--- a/lib/providers/playlist_provider.dart
+++ b/lib/providers/playlist_provider.dart
@@ -102,17 +102,31 @@ class PlaylistProvider with ChangeNotifier, StreamSubscriber {
     String? description,
     String? folderId,
   }) async {
-    await put('playlists/${playlist.id}', data: {
+    final response = await put('playlists/${playlist.id}', data: {
       'name': name,
       'description': description ?? '',
       'folder_id': folderId,
     });
 
-    playlist
-      ..name = name
-      ..description = description
-      ..folderId = folderId;
+    // Prefer the server response for fields it may resolve differently
+    // (notably folder_id, where koel's resource serializer reads the
+    // active folder via a separate query). Fall back to the request
+    // values if the server didn't echo them.
+    if (response is Map) {
+      playlist
+        ..name = (response['name'] as String?) ?? name
+        ..description = response['description'] as String?
+        ..folderId = response['folder_id'] as String?;
+    } else {
+      playlist
+        ..name = name
+        ..description = description
+        ..folderId = folderId;
+    }
 
+    // Reassign so subscribers that diff on list identity are
+    // guaranteed to pick up the in-place mutation.
+    _playlists = List.of(_playlists);
     notifyListeners();
   }
 

--- a/lib/providers/playlist_provider.dart
+++ b/lib/providers/playlist_provider.dart
@@ -108,16 +108,13 @@ class PlaylistProvider with ChangeNotifier, StreamSubscriber {
       'folder_id': folderId,
     });
 
-    // Prefer the server response for fields it may resolve differently
-    // (notably folder_id, where koel's resource serializer reads the
-    // active folder via a separate query).
     playlist
       ..name = response['name']
       ..description = response['description']
       ..folderId = response['folder_id'];
 
-    // Reassign so subscribers that diff on list identity are
-    // guaranteed to pick up the in-place mutation.
+    // Reassign so subscribers that diff on list identity rebuild
+    // even though only one item's fields changed.
     _playlists = List.of(_playlists);
     notifyListeners();
   }

--- a/lib/providers/playlist_provider.dart
+++ b/lib/providers/playlist_provider.dart
@@ -102,35 +102,19 @@ class PlaylistProvider with ChangeNotifier, StreamSubscriber {
     String? description,
     String? folderId,
   }) async {
-    final oldFolderId = playlist.folderId;
-
     final response = await put('playlists/${playlist.id}', data: {
       'name': name,
       'description': description ?? '',
+      'folder_id': folderId,
     });
 
     playlist
       ..name = response['name']
-      ..description = response['description'];
+      ..description = response['description']
+      ..folderId = response['folder_id'];
 
-    // Folder membership goes through the dedicated endpoints, which
-    // are the only ones that actually move a playlist between folders
-    // (and to root). PUT /playlists/:id leaves membership alone.
-    if (oldFolderId != folderId) {
-      if (folderId != null) {
-        // Adding to a folder also detaches from any current folder
-        // owned by this user (server-side behavior).
-        await post('playlist-folders/$folderId/playlists', data: {
-          'playlists': [playlist.id],
-        });
-      } else {
-        await delete('playlist-folders/$oldFolderId/playlists', data: {
-          'playlists': [playlist.id],
-        });
-      }
-      playlist.folderId = folderId;
-    }
-
+    // Reassign so subscribers that diff on list identity rebuild
+    // even though only one item's fields changed.
     _playlists = List.of(_playlists);
     notifyListeners();
   }

--- a/lib/providers/playlist_provider.dart
+++ b/lib/providers/playlist_provider.dart
@@ -110,19 +110,11 @@ class PlaylistProvider with ChangeNotifier, StreamSubscriber {
 
     // Prefer the server response for fields it may resolve differently
     // (notably folder_id, where koel's resource serializer reads the
-    // active folder via a separate query). Fall back to the request
-    // values if the server didn't echo them.
-    if (response is Map) {
-      playlist
-        ..name = (response['name'] as String?) ?? name
-        ..description = response['description'] as String?
-        ..folderId = response['folder_id'] as String?;
-    } else {
-      playlist
-        ..name = name
-        ..description = description
-        ..folderId = folderId;
-    }
+    // active folder via a separate query).
+    playlist
+      ..name = response['name']
+      ..description = response['description']
+      ..folderId = response['folder_id'];
 
     // Reassign so subscribers that diff on list identity are
     // guaranteed to pick up the in-place mutation.

--- a/lib/providers/playlist_provider.dart
+++ b/lib/providers/playlist_provider.dart
@@ -102,19 +102,35 @@ class PlaylistProvider with ChangeNotifier, StreamSubscriber {
     String? description,
     String? folderId,
   }) async {
+    final oldFolderId = playlist.folderId;
+
     final response = await put('playlists/${playlist.id}', data: {
       'name': name,
       'description': description ?? '',
-      'folder_id': folderId,
     });
 
     playlist
       ..name = response['name']
-      ..description = response['description']
-      ..folderId = response['folder_id'];
+      ..description = response['description'];
 
-    // Reassign so subscribers that diff on list identity rebuild
-    // even though only one item's fields changed.
+    // Folder membership goes through the dedicated endpoints, which
+    // are the only ones that actually move a playlist between folders
+    // (and to root). PUT /playlists/:id leaves membership alone.
+    if (oldFolderId != folderId) {
+      if (folderId != null) {
+        // Adding to a folder also detaches from any current folder
+        // owned by this user (server-side behavior).
+        await post('playlist-folders/$folderId/playlists', data: {
+          'playlists': [playlist.id],
+        });
+      } else {
+        await delete('playlist-folders/$oldFolderId/playlists', data: {
+          'playlists': [playlist.id],
+        });
+      }
+      playlist.folderId = folderId;
+    }
+
     _playlists = List.of(_playlists);
     notifyListeners();
   }


### PR DESCRIPTION
## Summary

After the edit-playlist sheet (#181) saves, the list row didn't visibly move into the destination folder even though the server had updated correctly. Two adjustments to `PlaylistProvider.update`:

- **Use the server's response**, not the request values. koel's `PlaylistResource` resolves `folder_id` via `PlaylistFolderService.getFolderForPlaylist`, which queries the active folder membership — that's the value to trust on the client, not the value we sent. Same for `name` / `description`.
- **Reassign `_playlists` to a fresh `List.of(_playlists)` before `notifyListeners()`** so any subscriber that's identity-diffing the list is guaranteed to rebuild. The in-place mutation alone wasn't reliably propagating.

## Test plan

- [x] `flutter test` passes for the touched files (model + playlist_row widget tests still green)
- [x] `flutter analyze` clean
- [ ] Manual smoke: edit a playlist that's currently in folder A, change the folder dropdown to B, save — confirm the row appears under folder B (and the count badge updates) without a manual refresh
- [ ] Manual smoke: same flow but moving from "no folder" → folder, and folder → "no folder"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Playlist editing now correctly reflects server-updated name and description immediately after save.
  * Moving a playlist between folders or to/from the root reliably updates its folder membership in the UI.
  * Playlist lists refresh instantly so changes are visible to users without manual refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->