### PR TITLE
Surface album Edit action gated on koel 9.2.0 permissions

### DIFF
--- a/lib/models/album.dart
+++ b/lib/models/album.dart
@@ -15,6 +15,12 @@ class Album {
   int playCount = 0;
   ImageProvider? _image;
 
+  /// Whether the current user is allowed to edit this album.
+  /// Sourced from the koel >= 9.2.0 `permissions.edit` flag on the
+  /// JSON resource. Defaults to `false` when the server didn't include
+  /// permissions (older koel) so the UI hides the action.
+  bool canEdit;
+
   Album({
     required this.id,
     required this.name,
@@ -22,6 +28,7 @@ class Album {
     required this.artistId,
     required this.artistName,
     this.year,
+    this.canEdit = false,
   });
 
   ImageProvider get image {
@@ -42,6 +49,8 @@ class Album {
   bool get isUnknownAlbum => name == 'Unknown Album';
 
   factory Album.fromJson(Map<String, dynamic> json) {
+    final permissions = json['permissions'];
+
     return Album(
       id: json['id'],
       name: json['name'],
@@ -49,6 +58,7 @@ class Album {
       artistId: json['artist_id'],
       artistName: json['artist_name'],
       year: json['year'] == null ? null : int.parse(json['year'].toString()),
+      canEdit: permissions is Map ? permissions['edit'] == true : false,
     );
   }
 
@@ -58,6 +68,7 @@ class Album {
     String? cover,
     int? playCount,
     Artist? artist,
+    bool canEdit = false,
   }) {
     Faker faker = Faker();
 
@@ -69,6 +80,7 @@ class Album {
       cover: cover ?? faker.image.loremPicsum(width: 192, height: 192),
       artistId: artist.id,
       artistName: artist.name,
+      canEdit: canEdit,
     )..playCount = playCount ?? faker.randomGenerator.integer(1000);
   }
 
@@ -79,7 +91,8 @@ class Album {
       ..cover = remote.cover
       ..name = remote.name
       ..year = remote.year
-      ..playCount = remote.playCount ?? 0;
+      ..playCount = remote.playCount ?? 0
+      ..canEdit = remote.canEdit;
 
     _image = null;
 

--- a/lib/providers/album_provider.dart
+++ b/lib/providers/album_provider.dart
@@ -107,4 +107,23 @@ class AlbumProvider with ChangeNotifier, StreamSubscriber {
 
     return paginate();
   }
+
+  Future<void> update(
+    Album album, {
+    required String name,
+    int? year,
+  }) async {
+    final response = await put('albums/${album.id}', data: {
+      'name': name,
+      'year': year,
+    });
+
+    album
+      ..name = response['name']
+      ..year = response['year'] == null
+          ? null
+          : int.parse(response['year'].toString());
+
+    notifyListeners();
+  }
 }

--- a/lib/ui/screens/albums.dart
+++ b/lib/ui/screens/albums.dart
@@ -192,7 +192,7 @@ class _AlbumsScreenState extends State<AlbumsScreen> {
   }
 }
 
-class AlbumRow extends StatelessWidget {
+class AlbumRow extends StatefulWidget {
   final Album album;
   final AppRouter router;
   final String sortField;
@@ -205,12 +205,30 @@ class AlbumRow extends StatelessWidget {
   }) : super(key: key);
 
   @override
+  State<AlbumRow> createState() => _AlbumRowState();
+}
+
+class _AlbumRowState extends State<AlbumRow> {
+  Offset? _lastTapPosition;
+
+  @override
   Widget build(BuildContext context) {
+    final album = widget.album;
+
     return Card(
       child: InkWell(
-        onTap: () => router.gotoAlbumDetailsScreen(
+        onTap: () => widget.router.gotoAlbumDetailsScreen(
           context,
           albumId: album.id,
+        ),
+        onTapDown: (details) => _lastTapPosition = details.globalPosition,
+        onLongPress: () => showAlbumActionsMenu(
+          context,
+          album: album,
+          position: _lastTapPosition ?? Offset.zero,
+          onUpdated: () {
+            if (mounted) setState(() {});
+          },
         ),
         child: ListTile(
           shape: Border(bottom: Divider.createBorderSide(context)),
@@ -221,7 +239,7 @@ class AlbumRow extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
             style: const TextStyle(color: Colors.white60),
           ),
-          trailing: sortField == 'year' && album.year != null
+          trailing: widget.sortField == 'year' && album.year != null
               ? Transform.translate(
                   offset: const Offset(8, -8),
                   child: Container(

--- a/lib/ui/screens/edit_album_sheet.dart
+++ b/lib/ui/screens/edit_album_sheet.dart
@@ -2,6 +2,7 @@ import 'package:app/models/models.dart';
 import 'package:app/providers/providers.dart';
 import 'package:app/ui/widgets/widgets.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 Future<void> showEditAlbumDialog(
@@ -52,6 +53,10 @@ Future<void> showEditAlbumDialog(
             controller: yearController,
             placeholder: 'Year (optional)',
             keyboardType: TextInputType.number,
+            inputFormatters: [
+              FilteringTextInputFormatter.digitsOnly,
+              LengthLimitingTextInputFormatter(4),
+            ],
           ),
         ],
       );

--- a/lib/ui/screens/edit_album_sheet.dart
+++ b/lib/ui/screens/edit_album_sheet.dart
@@ -1,0 +1,60 @@
+import 'package:app/models/models.dart';
+import 'package:app/providers/providers.dart';
+import 'package:app/ui/widgets/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+Future<void> showEditAlbumDialog(
+  BuildContext context, {
+  required Album album,
+}) async {
+  final nameController = TextEditingController(text: album.name);
+  final yearController =
+      TextEditingController(text: album.year?.toString() ?? '');
+  final albumProvider = context.read<AlbumProvider>();
+
+  await showFormSheet(
+    context,
+    title: 'Edit Album',
+    submitLabel: 'Save',
+    canSubmit: () => nameController.text.trim().isNotEmpty,
+    onSubmit: () async {
+      final name = nameController.text.trim();
+      if (name.isEmpty) return;
+
+      final yearText = yearController.text.trim();
+      final year = yearText.isEmpty ? null : int.tryParse(yearText);
+
+      try {
+        await albumProvider.update(album, name: name, year: year);
+        Navigator.pop(context);
+        showOverlay(context, caption: 'Album updated');
+      } catch (_) {
+        showOverlay(
+          context,
+          caption: 'Error',
+          message: 'Could not update album.',
+          icon: Icons.error_outline,
+        );
+      }
+    },
+    builder: (context, setState) {
+      return Column(
+        children: [
+          FormTextField(
+            controller: nameController,
+            placeholder: 'Album Name',
+            autofocus: true,
+            onChanged: (_) => setState(() {}),
+          ),
+          const SizedBox(height: 8),
+          FormTextField(
+            controller: yearController,
+            placeholder: 'Year (optional)',
+            keyboardType: TextInputType.number,
+          ),
+        ],
+      );
+    },
+  );
+}

--- a/lib/ui/screens/screens.dart
+++ b/lib/ui/screens/screens.dart
@@ -8,6 +8,7 @@ export 'create_playlist_folder_sheet.dart';
 export 'create_playlist_sheet.dart';
 export 'data_loading.dart';
 export 'downloaded.dart';
+export 'edit_album_sheet.dart';
 export 'edit_playlist_sheet.dart';
 export 'edit_radio_station_sheet.dart';
 export 'favorites.dart';

--- a/lib/ui/widgets/album_actions_menu.dart
+++ b/lib/ui/widgets/album_actions_menu.dart
@@ -1,0 +1,46 @@
+import 'package:app/models/models.dart';
+import 'package:app/ui/screens/edit_album_sheet.dart';
+import 'package:app/ui/widgets/widgets.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/services.dart';
+
+/// Shows the long-press context menu for an album — currently only Edit
+/// (the koel API doesn't expose a delete endpoint for albums).
+///
+/// Returns immediately when the user isn't permitted to edit (no
+/// haptic, no menu). Otherwise fires a medium haptic and opens the
+/// menu at [position] in global screen coordinates.
+///
+/// Pass [onUpdated] if the caller needs to rebuild after a successful
+/// edit (the provider mutates the album in place but doesn't notify
+/// individual row/card widgets).
+Future<void> showAlbumActionsMenu(
+  BuildContext context, {
+  required Album album,
+  required Offset position,
+  VoidCallback? onUpdated,
+}) async {
+  if (!album.canEdit) return;
+
+  HapticFeedback.mediumImpact();
+
+  final selected = await showFrostedContextMenu<String>(
+    context: context,
+    position: position,
+    items: const [
+      FrostedMenuItem(
+        value: 'edit',
+        icon: CupertinoIcons.pencil,
+        label: 'Edit',
+      ),
+    ],
+  );
+
+  if (!context.mounted) return;
+
+  if (selected == 'edit') {
+    await showEditAlbumDialog(context, album: album);
+    if (!context.mounted) return;
+    onUpdated?.call();
+  }
+}

--- a/lib/ui/widgets/album_card.dart
+++ b/lib/ui/widgets/album_card.dart
@@ -20,16 +20,28 @@ class AlbumCard extends StatefulWidget {
 class _AlbumCardState extends State<AlbumCard> {
   var _opacity = 1.0;
   final _cardWidth = 144.0;
+  Offset? _lastTapPosition;
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTapDown: (_) => setState(() => _opacity = 0.4),
+      onTapDown: (details) {
+        _lastTapPosition = details.globalPosition;
+        setState(() => _opacity = 0.4);
+      },
       onTapUp: (_) => setState(() => _opacity = 1.0),
       onTapCancel: () => setState(() => _opacity = 1.0),
       onTap: () => widget.router.gotoAlbumDetailsScreen(
         context,
         albumId: widget.album.id,
+      ),
+      onLongPress: () => showAlbumActionsMenu(
+        context,
+        album: widget.album,
+        position: _lastTapPosition ?? Offset.zero,
+        onUpdated: () {
+          if (mounted) setState(() {});
+        },
       ),
       behavior: HitTestBehavior.opaque,
       child: AnimatedOpacity(

--- a/lib/ui/widgets/form_sheet.dart
+++ b/lib/ui/widgets/form_sheet.dart
@@ -2,6 +2,7 @@ import 'package:app/constants/constants.dart';
 import 'package:app/ui/widgets/widgets.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 /// A reusable bottom sheet with a title, form fields, and action buttons.
 /// Used for creating/editing playlists, folders, radio stations, etc.
@@ -159,6 +160,7 @@ class FormTextField extends StatefulWidget {
   final bool autofocus;
   final int maxLines;
   final TextInputType? keyboardType;
+  final List<TextInputFormatter>? inputFormatters;
   final ValueChanged<String>? onChanged;
 
   const FormTextField({
@@ -168,6 +170,7 @@ class FormTextField extends StatefulWidget {
     this.autofocus = false,
     this.maxLines = 1,
     this.keyboardType,
+    this.inputFormatters,
     this.onChanged,
   }) : super(key: key);
 
@@ -204,6 +207,7 @@ class _FormTextFieldState extends State<FormTextField> {
       autofocus: widget.autofocus,
       maxLines: widget.maxLines,
       keyboardType: widget.keyboardType,
+      inputFormatters: widget.inputFormatters,
       onChanged: (value) {
         setState(() {});
         widget.onChanged?.call(value);

--- a/lib/ui/widgets/widgets.dart
+++ b/lib/ui/widgets/widgets.dart
@@ -1,3 +1,4 @@
+export 'album_actions_menu.dart';
 export 'album_artist_thumbnail.dart';
 export 'alphabet_scrollbar.dart';
 export 'album_card.dart';

--- a/test/models/album_test.dart
+++ b/test/models/album_test.dart
@@ -34,6 +34,41 @@ void main() {
       final album = Album.fromJson(json);
       expect(album.cover, isNull);
     });
+
+    test('parses canEdit from permissions', () {
+      final json = {
+        'id': 1,
+        'name': 'Perm',
+        'artist_id': 1,
+        'artist_name': 'A',
+        'permissions': {'edit': true},
+      };
+
+      expect(Album.fromJson(json).canEdit, isTrue);
+    });
+
+    test('defaults canEdit to false when permissions is absent', () {
+      final json = {
+        'id': 1,
+        'name': 'Old Server',
+        'artist_id': 1,
+        'artist_name': 'A',
+      };
+
+      expect(Album.fromJson(json).canEdit, isFalse);
+    });
+
+    test('defaults canEdit to false when permissions.edit is non-bool', () {
+      final json = {
+        'id': 1,
+        'name': 'Partial',
+        'artist_id': 1,
+        'artist_name': 'A',
+        'permissions': {'edit': null},
+      };
+
+      expect(Album.fromJson(json).canEdit, isFalse);
+    });
   });
 
   group('Album boolean properties', () {
@@ -58,6 +93,14 @@ void main() {
       expect(local.name, 'New Name');
       expect(local.cover, remote.cover);
       expect(local.artistName, remote.artistName);
+    });
+
+    test('merges canEdit from remote', () {
+      final local = Album.fake(canEdit: false);
+      final remote = Album.fake(canEdit: true);
+
+      local.merge(remote);
+      expect(local.canEdit, isTrue);
     });
   });
 

--- a/test/ui/widgets/album_card_test.dart
+++ b/test/ui/widgets/album_card_test.dart
@@ -1,16 +1,18 @@
 import 'package:app/models/album.dart';
 import 'package:app/models/artist.dart';
+import 'package:app/providers/album_provider.dart';
 import 'package:app/router.dart';
 import 'package:app/ui/widgets/album_artist_thumbnail.dart';
 import 'package:app/ui/widgets/album_card.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
 
 import '../../extensions/widget_tester_extension.dart';
 import 'album_card_test.mocks.dart';
 
-@GenerateMocks([AppRouter])
+@GenerateMocks([AppRouter, AlbumProvider])
 void main() {
   late Album album;
 
@@ -39,5 +41,36 @@ void main() {
 
     await tester.tap(find.text('A Whole New Bunch'));
     verify(router.gotoAlbumDetailsScreen(any, albumId: album.id)).called(1);
+  });
+
+  group('long-press context menu', () {
+    Future<void> mountWithProvider(WidgetTester tester, Album album) async {
+      await tester.pumpAppWidget(
+        ChangeNotifierProvider<AlbumProvider>.value(
+          value: MockAlbumProvider(),
+          child: AlbumCard(album: album),
+        ),
+      );
+    }
+
+    testWidgets('shows Edit when canEdit', (tester) async {
+      final editable = Album.fake(name: 'Editable', canEdit: true);
+      await mountWithProvider(tester, editable);
+
+      await tester.longPress(find.byType(AlbumCard));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Edit'), findsOneWidget);
+    });
+
+    testWidgets('no menu when canEdit is false', (tester) async {
+      final readonly = Album.fake(name: 'Read-only');
+      await mountWithProvider(tester, readonly);
+
+      await tester.longPress(find.byType(AlbumCard));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Edit'), findsNothing);
+    });
   });
 }

--- a/test/ui/widgets/album_card_test.mocks.dart
+++ b/test/ui/widgets/album_card_test.mocks.dart
@@ -3,12 +3,16 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i3;
+import 'dart:async' as _i4;
+import 'dart:ui' as _i9;
 
-import 'package:app/models/models.dart' as _i5;
-import 'package:app/router.dart' as _i2;
-import 'package:flutter/cupertino.dart' as _i4;
+import 'package:app/enums.dart' as _i8;
+import 'package:app/models/models.dart' as _i2;
+import 'package:app/providers/album_provider.dart' as _i6;
+import 'package:app/router.dart' as _i3;
+import 'package:flutter/cupertino.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:mockito/src/dummies.dart' as _i7;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -24,17 +28,27 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
+class _FakeAlbum_0 extends _i1.SmartFake implements _i2.Album {
+  _FakeAlbum_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [AppRouter].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAppRouter extends _i1.Mock implements _i2.AppRouter {
+class MockAppRouter extends _i1.Mock implements _i3.AppRouter {
   MockAppRouter() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i3.Future<void> gotoAlbumDetailsScreen(
-    _i4.BuildContext? context, {
+  _i4.Future<void> gotoAlbumDetailsScreen(
+    _i5.BuildContext? context, {
     required dynamic albumId,
   }) =>
       (super.noSuchMethod(
@@ -43,13 +57,13 @@ class MockAppRouter extends _i1.Mock implements _i2.AppRouter {
           [context],
           {#albumId: albumId},
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 
   @override
-  _i3.Future<void> gotoArtistDetailsScreen(
-    _i4.BuildContext? context, {
+  _i4.Future<void> gotoArtistDetailsScreen(
+    _i5.BuildContext? context, {
     required dynamic artistId,
   }) =>
       (super.noSuchMethod(
@@ -58,13 +72,13 @@ class MockAppRouter extends _i1.Mock implements _i2.AppRouter {
           [context],
           {#artistId: artistId},
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 
   @override
   dynamic gotoPodcastDetailsScreen(
-    _i4.BuildContext? context, {
+    _i5.BuildContext? context, {
     required String? podcastId,
   }) =>
       super.noSuchMethod(Invocation.method(
@@ -75,8 +89,8 @@ class MockAppRouter extends _i1.Mock implements _i2.AppRouter {
 
   @override
   dynamic gotoGenreDetailsScreen(
-    _i4.BuildContext? context, {
-    required _i5.Genre? genre,
+    _i5.BuildContext? context, {
+    required _i2.Genre? genre,
   }) =>
       super.noSuchMethod(Invocation.method(
         #gotoGenreDetailsScreen,
@@ -85,42 +99,42 @@ class MockAppRouter extends _i1.Mock implements _i2.AppRouter {
       ));
 
   @override
-  _i3.Future<void> openNowPlayingScreen(_i4.BuildContext? context) =>
+  _i4.Future<void> openNowPlayingScreen(_i5.BuildContext? context) =>
       (super.noSuchMethod(
         Invocation.method(
           #openNowPlayingScreen,
           [context],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 
   @override
-  _i3.Future<void> showCreatePlaylistSheet(_i4.BuildContext? context) =>
+  _i4.Future<void> showCreatePlaylistSheet(_i5.BuildContext? context) =>
       (super.noSuchMethod(
         Invocation.method(
           #showCreatePlaylistSheet,
           [context],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 
   @override
-  _i3.Future<void> showCreatePlaylistFolderSheet(_i4.BuildContext? context) =>
+  _i4.Future<void> showCreatePlaylistFolderSheet(_i5.BuildContext? context) =>
       (super.noSuchMethod(
         Invocation.method(
           #showCreatePlaylistFolderSheet,
           [context],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 
   @override
-  _i3.Future<void> showPlayableActionSheet(
-    _i4.BuildContext? context, {
-    required _i5.Playable<dynamic>? playable,
+  _i4.Future<void> showPlayableActionSheet(
+    _i5.BuildContext? context, {
+    required _i2.Playable<dynamic>? playable,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -128,18 +142,213 @@ class MockAppRouter extends _i1.Mock implements _i2.AppRouter {
           [context],
           {#playable: playable},
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 
   @override
-  _i3.Future<void> showAddPodcastSheet(_i4.BuildContext? context) =>
+  _i4.Future<void> showAddPodcastSheet(_i5.BuildContext? context) =>
       (super.noSuchMethod(
         Invocation.method(
           #showAddPodcastSheet,
           [context],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+}
+
+/// A class which mocks [AlbumProvider].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockAlbumProvider extends _i1.Mock implements _i6.AlbumProvider {
+  MockAlbumProvider() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  List<_i2.Album> get albums => (super.noSuchMethod(
+        Invocation.getter(#albums),
+        returnValue: <_i2.Album>[],
+      ) as List<_i2.Album>);
+
+  @override
+  String get sortField => (super.noSuchMethod(
+        Invocation.getter(#sortField),
+        returnValue: _i7.dummyValue<String>(
+          this,
+          Invocation.getter(#sortField),
+        ),
+      ) as String);
+
+  @override
+  _i8.SortOrder get sortOrder => (super.noSuchMethod(
+        Invocation.getter(#sortOrder),
+        returnValue: _i8.SortOrder.asc,
+      ) as _i8.SortOrder);
+
+  @override
+  set albums(List<_i2.Album>? _albums) => super.noSuchMethod(
+        Invocation.setter(
+          #albums,
+          _albums,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sortField(String? field) => super.noSuchMethod(
+        Invocation.setter(
+          #sortField,
+          field,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sortOrder(_i8.SortOrder? order) => super.noSuchMethod(
+        Invocation.setter(
+          #sortOrder,
+          order,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  List<_i2.Album> byIds(List<dynamic>? ids) => (super.noSuchMethod(
+        Invocation.method(
+          #byIds,
+          [ids],
+        ),
+        returnValue: <_i2.Album>[],
+      ) as List<_i2.Album>);
+
+  @override
+  _i4.Future<_i2.Album> resolve(
+    dynamic id, {
+    bool? forceRefresh = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #resolve,
+          [id],
+          {#forceRefresh: forceRefresh},
+        ),
+        returnValue: _i4.Future<_i2.Album>.value(_FakeAlbum_0(
+          this,
+          Invocation.method(
+            #resolve,
+            [id],
+            {#forceRefresh: forceRefresh},
+          ),
+        )),
+      ) as _i4.Future<_i2.Album>);
+
+  @override
+  List<_i2.Album> syncWithVault(dynamic _albums) => (super.noSuchMethod(
+        Invocation.method(
+          #syncWithVault,
+          [_albums],
+        ),
+        returnValue: <_i2.Album>[],
+      ) as List<_i2.Album>);
+
+  @override
+  _i4.Future<void> paginate() => (super.noSuchMethod(
+        Invocation.method(
+          #paginate,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+
+  @override
+  _i4.Future<void> refresh() => (super.noSuchMethod(
+        Invocation.method(
+          #refresh,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+
+  @override
+  _i4.Future<void> update(
+    _i2.Album? album, {
+    required String? name,
+    int? year,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #update,
+          [album],
+          {
+            #name: name,
+            #year: year,
+          },
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+
+  @override
+  void addListener(_i9.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void removeListener(_i9.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void unsubscribeAll() => super.noSuchMethod(
+        Invocation.method(
+          #unsubscribeAll,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void subscribe(_i4.StreamSubscription<dynamic>? sub) => super.noSuchMethod(
+        Invocation.method(
+          #subscribe,
+          [sub],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/test/ui/widgets/album_row_test.dart
+++ b/test/ui/widgets/album_row_test.dart
@@ -1,0 +1,42 @@
+import 'package:app/models/album.dart';
+import 'package:app/providers/album_provider.dart';
+import 'package:app/ui/screens/albums.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import '../../extensions/widget_tester_extension.dart';
+import 'album_card_test.mocks.dart';
+
+void main() {
+  Future<void> mountWithProvider(WidgetTester tester, Album album) async {
+    await tester.pumpAppWidget(
+      ChangeNotifierProvider<AlbumProvider>.value(
+        value: MockAlbumProvider(),
+        child: AlbumRow(
+          album: album,
+          router: MockAppRouter(),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('shows Edit on long-press when canEdit', (tester) async {
+    final album = Album.fake(name: 'Editable', canEdit: true);
+    await mountWithProvider(tester, album);
+
+    await tester.longPress(find.byType(AlbumRow));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Edit'), findsOneWidget);
+  });
+
+  testWidgets('no menu on long-press when canEdit is false', (tester) async {
+    final album = Album.fake(name: 'Read-only');
+    await mountWithProvider(tester, album);
+
+    await tester.longPress(find.byType(AlbumRow));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Edit'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

Same pattern as #181 (playlists) and #183 (radio stations), now for albums. Albums only expose `permissions.edit` on the server (no delete), so the menu is a single item.

### Model

- `Album.fromJson` parses `permissions.edit` into a new `canEdit` flag. Defaults to `false` when `permissions` is absent (older koel) or its inner value isn't a bool. `Album.merge` propagates `canEdit` from the remote so synced instances stay in sync.

### Provider

- New `AlbumProvider.update(album, name, year)` that PUTs `/albums/:id`, mirrors the server's response onto the album instance, and notifies. Cover and other fields are out of scope here.

### Edit UI

- **Long-press an `AlbumCard`** (used on the home screen and in search results) opens a frosted context menu with **Edit**, only when the user is permitted. Tap continues to navigate to `AlbumDetailsScreen`. No-op when `canEdit` is false.
- **Edit** opens a new `showEditAlbumDialog` with name + year fields, matching the form-sheet pattern used by the other resource edit flows.

The long-press helper lives in `lib/ui/widgets/album_actions_menu.dart` (`showAlbumActionsMenu`), exported from `widgets.dart`.

## Test plan

- [x] `flutter test` — full suite green (257/257)
- [x] Model tests cover the three permissions parsing branches (present / missing / non-bool) and the new `Album.merge` propagation case
- [x] `AlbumCard` widget tests cover the two long-press cases (menu visible when `canEdit` / no menu when not)
- [x] `flutter analyze` clean on touched files
- [ ] Smoke test against a 9.2.0 backend with two users; confirm long-press surfaces the menu for the owner and is a no-op for the other
- [ ] Smoke test the long-press on both the home screen and search-results album cards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit album dialog to change name and year with validation and success/error messaging
  * Long-press album cards/rows to open a context menu with an Edit option when allowed
  * Edit availability is gated by album-level permission so only editable albums show Edit

* **Quality**
  * Immediate UI refresh after edits and added tests covering edit/permission behaviors

* **UX**
  * Year input constrained to numeric entry with length limit for consistent input
<!-- end of auto-generated comment: release notes by coderabbit.ai -->