### PR TITLE
Surface artist Edit action gated on koel 9.2.0 permissions

### DIFF
--- a/lib/models/artist.dart
+++ b/lib/models/artist.dart
@@ -11,7 +11,18 @@ class Artist {
   int playCount = 0;
   ImageProvider? _image;
 
-  Artist({required this.id, required this.name, required this.imageUrl});
+  /// Whether the current user is allowed to edit this artist.
+  /// Sourced from the koel >= 9.2.0 `permissions.edit` flag on the JSON
+  /// resource. Defaults to `false` when the server didn't include
+  /// permissions (older koel) so the UI hides the action.
+  bool canEdit;
+
+  Artist({
+    required this.id,
+    required this.name,
+    required this.imageUrl,
+    this.canEdit = false,
+  });
 
   ImageProvider get image {
     var image = _image;
@@ -33,10 +44,13 @@ class Artist {
   bool get isVariousArtists => name == 'Various Artists';
 
   factory Artist.fromJson(Map<String, dynamic> json) {
+    final permissions = json['permissions'];
+
     return Artist(
       id: json['id'],
       name: json['name'],
       imageUrl: json['image'],
+      canEdit: permissions is Map ? permissions['edit'] == true : false,
     );
   }
 
@@ -45,6 +59,7 @@ class Artist {
     String? name,
     String? imageUrl,
     int? playCount,
+    bool canEdit = false,
   }) {
     Faker faker = Faker();
 
@@ -52,6 +67,7 @@ class Artist {
       id: id ?? Ulid().toString(),
       name: name ?? faker.person.name(),
       imageUrl: imageUrl ?? faker.image.loremPicsum(width: 192, height: 192),
+      canEdit: canEdit,
     )..playCount = playCount ?? faker.randomGenerator.integer(1000);
   }
 
@@ -59,7 +75,8 @@ class Artist {
     this
       ..imageUrl = remote.imageUrl
       ..playCount = remote.playCount ?? 0
-      ..name = remote.name;
+      ..name = remote.name
+      ..canEdit = remote.canEdit;
 
     _image = null;
 

--- a/lib/providers/artist_provider.dart
+++ b/lib/providers/artist_provider.dart
@@ -107,4 +107,14 @@ class ArtistProvider with ChangeNotifier, StreamSubscriber {
 
     return paginate();
   }
+
+  Future<void> update(Artist artist, {required String name}) async {
+    final response = await put('artists/${artist.id}', data: {
+      'name': name,
+    });
+
+    artist.name = response['name'];
+
+    notifyListeners();
+  }
 }

--- a/lib/ui/screens/artists.dart
+++ b/lib/ui/screens/artists.dart
@@ -190,7 +190,7 @@ class _ArtistsScreenState extends State<ArtistsScreen> {
   }
 }
 
-class ArtistRow extends StatelessWidget {
+class ArtistRow extends StatefulWidget {
   final Artist artist;
   final AppRouter router;
 
@@ -198,12 +198,30 @@ class ArtistRow extends StatelessWidget {
       : super(key: key);
 
   @override
+  State<ArtistRow> createState() => _ArtistRowState();
+}
+
+class _ArtistRowState extends State<ArtistRow> {
+  Offset? _lastTapPosition;
+
+  @override
   Widget build(BuildContext context) {
+    final artist = widget.artist;
+
     return Card(
       child: InkWell(
-        onTap: () => router.gotoArtistDetailsScreen(
+        onTap: () => widget.router.gotoArtistDetailsScreen(
           context,
           artistId: artist.id,
+        ),
+        onTapDown: (details) => _lastTapPosition = details.globalPosition,
+        onLongPress: () => showArtistActionsMenu(
+          context,
+          artist: artist,
+          position: _lastTapPosition ?? Offset.zero,
+          onUpdated: () {
+            if (mounted) setState(() {});
+          },
         ),
         child: ListTile(
           shape: Border(bottom: Divider.createBorderSide(context)),

--- a/lib/ui/screens/edit_artist_sheet.dart
+++ b/lib/ui/screens/edit_artist_sheet.dart
@@ -1,0 +1,49 @@
+import 'package:app/models/models.dart';
+import 'package:app/providers/providers.dart';
+import 'package:app/ui/widgets/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+Future<void> showEditArtistDialog(
+  BuildContext context, {
+  required Artist artist,
+}) async {
+  final nameController = TextEditingController(text: artist.name);
+  final artistProvider = context.read<ArtistProvider>();
+
+  await showFormSheet(
+    context,
+    title: 'Edit Artist',
+    submitLabel: 'Save',
+    canSubmit: () => nameController.text.trim().isNotEmpty,
+    onSubmit: () async {
+      final name = nameController.text.trim();
+      if (name.isEmpty) return;
+
+      try {
+        await artistProvider.update(artist, name: name);
+        Navigator.pop(context);
+        showOverlay(context, caption: 'Artist updated');
+      } catch (_) {
+        showOverlay(
+          context,
+          caption: 'Error',
+          message: 'Could not update artist.',
+          icon: Icons.error_outline,
+        );
+      }
+    },
+    builder: (context, setState) {
+      return Column(
+        children: [
+          FormTextField(
+            controller: nameController,
+            placeholder: 'Artist Name',
+            autofocus: true,
+            onChanged: (_) => setState(() {}),
+          ),
+        ],
+      );
+    },
+  );
+}

--- a/lib/ui/screens/screens.dart
+++ b/lib/ui/screens/screens.dart
@@ -9,6 +9,7 @@ export 'create_playlist_sheet.dart';
 export 'data_loading.dart';
 export 'downloaded.dart';
 export 'edit_album_sheet.dart';
+export 'edit_artist_sheet.dart';
 export 'edit_playlist_sheet.dart';
 export 'edit_radio_station_sheet.dart';
 export 'favorites.dart';

--- a/lib/ui/widgets/artist_actions_menu.dart
+++ b/lib/ui/widgets/artist_actions_menu.dart
@@ -1,0 +1,46 @@
+import 'package:app/models/models.dart';
+import 'package:app/ui/screens/edit_artist_sheet.dart';
+import 'package:app/ui/widgets/widgets.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/services.dart';
+
+/// Shows the long-press context menu for an artist — currently only Edit
+/// (the koel API doesn't expose a delete endpoint for artists).
+///
+/// Returns immediately when the user isn't permitted to edit (no
+/// haptic, no menu). Otherwise fires a medium haptic and opens the
+/// menu at [position] in global screen coordinates.
+///
+/// Pass [onUpdated] if the caller needs to rebuild after a successful
+/// edit (the provider mutates the artist in place but doesn't notify
+/// individual row/card widgets).
+Future<void> showArtistActionsMenu(
+  BuildContext context, {
+  required Artist artist,
+  required Offset position,
+  VoidCallback? onUpdated,
+}) async {
+  if (!artist.canEdit) return;
+
+  HapticFeedback.mediumImpact();
+
+  final selected = await showFrostedContextMenu<String>(
+    context: context,
+    position: position,
+    items: const [
+      FrostedMenuItem(
+        value: 'edit',
+        icon: CupertinoIcons.pencil,
+        label: 'Edit',
+      ),
+    ],
+  );
+
+  if (!context.mounted) return;
+
+  if (selected == 'edit') {
+    await showEditArtistDialog(context, artist: artist);
+    if (!context.mounted) return;
+    onUpdated?.call();
+  }
+}

--- a/lib/ui/widgets/artist_card.dart
+++ b/lib/ui/widgets/artist_card.dart
@@ -21,16 +21,28 @@ class ArtistCard extends StatefulWidget {
 class _ArtistCardState extends State<ArtistCard> {
   var _opacity = 1.0;
   final _cardWidth = 144.0;
+  Offset? _lastTapPosition;
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTapDown: (_) => setState(() => _opacity = 0.4),
+      onTapDown: (details) {
+        _lastTapPosition = details.globalPosition;
+        setState(() => _opacity = 0.4);
+      },
       onTapUp: (_) => setState(() => _opacity = 1.0),
       onTapCancel: () => setState(() => _opacity = 1.0),
       onTap: () => widget.router.gotoArtistDetailsScreen(
         context,
         artistId: widget.artist.id,
+      ),
+      onLongPress: () => showArtistActionsMenu(
+        context,
+        artist: widget.artist,
+        position: _lastTapPosition ?? Offset.zero,
+        onUpdated: () {
+          if (mounted) setState(() {});
+        },
       ),
       behavior: HitTestBehavior.opaque,
       child: AnimatedOpacity(

--- a/lib/ui/widgets/widgets.dart
+++ b/lib/ui/widgets/widgets.dart
@@ -3,6 +3,7 @@ export 'album_artist_thumbnail.dart';
 export 'alphabet_scrollbar.dart';
 export 'album_card.dart';
 export 'app_bar.dart';
+export 'artist_actions_menu.dart';
 export 'artist_card.dart';
 export 'bottom_space.dart';
 export 'decorated_image_box.dart';

--- a/test/models/artist_test.dart
+++ b/test/models/artist_test.dart
@@ -27,6 +27,38 @@ void main() {
       final artist = Artist.fromJson(json);
       expect(artist.imageUrl, isNull);
     });
+
+    test('parses canEdit from permissions', () {
+      final json = {
+        'id': 1,
+        'name': 'Perm',
+        'image': null,
+        'permissions': {'edit': true},
+      };
+
+      expect(Artist.fromJson(json).canEdit, isTrue);
+    });
+
+    test('defaults canEdit to false when permissions is absent', () {
+      final json = {
+        'id': 1,
+        'name': 'Old Server',
+        'image': null,
+      };
+
+      expect(Artist.fromJson(json).canEdit, isFalse);
+    });
+
+    test('defaults canEdit to false when permissions.edit is non-bool', () {
+      final json = {
+        'id': 1,
+        'name': 'Partial',
+        'image': null,
+        'permissions': {'edit': null},
+      };
+
+      expect(Artist.fromJson(json).canEdit, isFalse);
+    });
   });
 
   group('Artist boolean properties', () {
@@ -56,6 +88,14 @@ void main() {
 
       expect(local.name, 'New Name');
       expect(local.imageUrl, remote.imageUrl);
+    });
+
+    test('merges canEdit from remote', () {
+      final local = Artist.fake(canEdit: false);
+      final remote = Artist.fake(canEdit: true);
+
+      local.merge(remote);
+      expect(local.canEdit, isTrue);
     });
   });
 

--- a/test/ui/widgets/artist_card_test.dart
+++ b/test/ui/widgets/artist_card_test.dart
@@ -1,15 +1,17 @@
 import 'package:app/models/artist.dart';
+import 'package:app/providers/artist_provider.dart';
 import 'package:app/router.dart';
 import 'package:app/ui/widgets/artist_card.dart';
 import 'package:app/ui/widgets/album_artist_thumbnail.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
 
 import '../../extensions/widget_tester_extension.dart';
 import 'artist_card_test.mocks.dart';
 
-@GenerateMocks([AppRouter])
+@GenerateMocks([AppRouter, ArtistProvider])
 void main() {
   late Artist artist;
 
@@ -34,5 +36,36 @@ void main() {
 
     await tester.tap(find.text('Banana'));
     verify(router.gotoArtistDetailsScreen(any, artistId: artist.id)).called(1);
+  });
+
+  group('long-press context menu', () {
+    Future<void> mountWithProvider(WidgetTester tester, Artist artist) async {
+      await tester.pumpAppWidget(
+        ChangeNotifierProvider<ArtistProvider>.value(
+          value: MockArtistProvider(),
+          child: ArtistCard(artist: artist),
+        ),
+      );
+    }
+
+    testWidgets('shows Edit when canEdit', (tester) async {
+      final editable = Artist.fake(name: 'Editable', canEdit: true);
+      await mountWithProvider(tester, editable);
+
+      await tester.longPress(find.byType(ArtistCard));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Edit'), findsOneWidget);
+    });
+
+    testWidgets('no menu when canEdit is false', (tester) async {
+      final readonly = Artist.fake(name: 'Read-only');
+      await mountWithProvider(tester, readonly);
+
+      await tester.longPress(find.byType(ArtistCard));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Edit'), findsNothing);
+    });
   });
 }

--- a/test/ui/widgets/artist_card_test.mocks.dart
+++ b/test/ui/widgets/artist_card_test.mocks.dart
@@ -3,12 +3,16 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i3;
+import 'dart:async' as _i4;
+import 'dart:ui' as _i9;
 
-import 'package:app/models/models.dart' as _i5;
-import 'package:app/router.dart' as _i2;
-import 'package:flutter/cupertino.dart' as _i4;
+import 'package:app/enums.dart' as _i8;
+import 'package:app/models/models.dart' as _i2;
+import 'package:app/providers/providers.dart' as _i6;
+import 'package:app/router.dart' as _i3;
+import 'package:flutter/cupertino.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:mockito/src/dummies.dart' as _i7;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -24,17 +28,27 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
+class _FakeArtist_0 extends _i1.SmartFake implements _i2.Artist {
+  _FakeArtist_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [AppRouter].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAppRouter extends _i1.Mock implements _i2.AppRouter {
+class MockAppRouter extends _i1.Mock implements _i3.AppRouter {
   MockAppRouter() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i3.Future<void> gotoAlbumDetailsScreen(
-    _i4.BuildContext? context, {
+  _i4.Future<void> gotoAlbumDetailsScreen(
+    _i5.BuildContext? context, {
     required dynamic albumId,
   }) =>
       (super.noSuchMethod(
@@ -43,13 +57,13 @@ class MockAppRouter extends _i1.Mock implements _i2.AppRouter {
           [context],
           {#albumId: albumId},
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 
   @override
-  _i3.Future<void> gotoArtistDetailsScreen(
-    _i4.BuildContext? context, {
+  _i4.Future<void> gotoArtistDetailsScreen(
+    _i5.BuildContext? context, {
     required dynamic artistId,
   }) =>
       (super.noSuchMethod(
@@ -58,13 +72,13 @@ class MockAppRouter extends _i1.Mock implements _i2.AppRouter {
           [context],
           {#artistId: artistId},
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 
   @override
   dynamic gotoPodcastDetailsScreen(
-    _i4.BuildContext? context, {
+    _i5.BuildContext? context, {
     required String? podcastId,
   }) =>
       super.noSuchMethod(Invocation.method(
@@ -75,8 +89,8 @@ class MockAppRouter extends _i1.Mock implements _i2.AppRouter {
 
   @override
   dynamic gotoGenreDetailsScreen(
-    _i4.BuildContext? context, {
-    required _i5.Genre? genre,
+    _i5.BuildContext? context, {
+    required _i2.Genre? genre,
   }) =>
       super.noSuchMethod(Invocation.method(
         #gotoGenreDetailsScreen,
@@ -85,42 +99,42 @@ class MockAppRouter extends _i1.Mock implements _i2.AppRouter {
       ));
 
   @override
-  _i3.Future<void> openNowPlayingScreen(_i4.BuildContext? context) =>
+  _i4.Future<void> openNowPlayingScreen(_i5.BuildContext? context) =>
       (super.noSuchMethod(
         Invocation.method(
           #openNowPlayingScreen,
           [context],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 
   @override
-  _i3.Future<void> showCreatePlaylistSheet(_i4.BuildContext? context) =>
+  _i4.Future<void> showCreatePlaylistSheet(_i5.BuildContext? context) =>
       (super.noSuchMethod(
         Invocation.method(
           #showCreatePlaylistSheet,
           [context],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 
   @override
-  _i3.Future<void> showCreatePlaylistFolderSheet(_i4.BuildContext? context) =>
+  _i4.Future<void> showCreatePlaylistFolderSheet(_i5.BuildContext? context) =>
       (super.noSuchMethod(
         Invocation.method(
           #showCreatePlaylistFolderSheet,
           [context],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 
   @override
-  _i3.Future<void> showPlayableActionSheet(
-    _i4.BuildContext? context, {
-    required _i5.Playable<dynamic>? playable,
+  _i4.Future<void> showPlayableActionSheet(
+    _i5.BuildContext? context, {
+    required _i2.Playable<dynamic>? playable,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -128,18 +142,209 @@ class MockAppRouter extends _i1.Mock implements _i2.AppRouter {
           [context],
           {#playable: playable},
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 
   @override
-  _i3.Future<void> showAddPodcastSheet(_i4.BuildContext? context) =>
+  _i4.Future<void> showAddPodcastSheet(_i5.BuildContext? context) =>
       (super.noSuchMethod(
         Invocation.method(
           #showAddPodcastSheet,
           [context],
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+}
+
+/// A class which mocks [ArtistProvider].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockArtistProvider extends _i1.Mock implements _i6.ArtistProvider {
+  MockArtistProvider() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  List<_i2.Artist> get artists => (super.noSuchMethod(
+        Invocation.getter(#artists),
+        returnValue: <_i2.Artist>[],
+      ) as List<_i2.Artist>);
+
+  @override
+  String get sortField => (super.noSuchMethod(
+        Invocation.getter(#sortField),
+        returnValue: _i7.dummyValue<String>(
+          this,
+          Invocation.getter(#sortField),
+        ),
+      ) as String);
+
+  @override
+  _i8.SortOrder get sortOrder => (super.noSuchMethod(
+        Invocation.getter(#sortOrder),
+        returnValue: _i8.SortOrder.asc,
+      ) as _i8.SortOrder);
+
+  @override
+  set artists(List<_i2.Artist>? _artists) => super.noSuchMethod(
+        Invocation.setter(
+          #artists,
+          _artists,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sortField(String? field) => super.noSuchMethod(
+        Invocation.setter(
+          #sortField,
+          field,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sortOrder(_i8.SortOrder? order) => super.noSuchMethod(
+        Invocation.setter(
+          #sortOrder,
+          order,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  List<_i2.Artist> byIds(List<dynamic>? ids) => (super.noSuchMethod(
+        Invocation.method(
+          #byIds,
+          [ids],
+        ),
+        returnValue: <_i2.Artist>[],
+      ) as List<_i2.Artist>);
+
+  @override
+  _i4.Future<_i2.Artist> resolve(
+    dynamic id, {
+    bool? forceRefresh = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #resolve,
+          [id],
+          {#forceRefresh: forceRefresh},
+        ),
+        returnValue: _i4.Future<_i2.Artist>.value(_FakeArtist_0(
+          this,
+          Invocation.method(
+            #resolve,
+            [id],
+            {#forceRefresh: forceRefresh},
+          ),
+        )),
+      ) as _i4.Future<_i2.Artist>);
+
+  @override
+  List<_i2.Artist> syncWithVault(dynamic _artists) => (super.noSuchMethod(
+        Invocation.method(
+          #syncWithVault,
+          [_artists],
+        ),
+        returnValue: <_i2.Artist>[],
+      ) as List<_i2.Artist>);
+
+  @override
+  _i4.Future<void> paginate() => (super.noSuchMethod(
+        Invocation.method(
+          #paginate,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+
+  @override
+  _i4.Future<void> refresh() => (super.noSuchMethod(
+        Invocation.method(
+          #refresh,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+
+  @override
+  _i4.Future<void> update(
+    _i2.Artist? artist, {
+    required String? name,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #update,
+          [artist],
+          {#name: name},
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+
+  @override
+  void addListener(_i9.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void removeListener(_i9.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void unsubscribeAll() => super.noSuchMethod(
+        Invocation.method(
+          #unsubscribeAll,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void subscribe(_i4.StreamSubscription<dynamic>? sub) => super.noSuchMethod(
+        Invocation.method(
+          #subscribe,
+          [sub],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/test/ui/widgets/artist_row_test.dart
+++ b/test/ui/widgets/artist_row_test.dart
@@ -1,0 +1,39 @@
+import 'package:app/models/artist.dart';
+import 'package:app/providers/artist_provider.dart';
+import 'package:app/ui/screens/artists.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import '../../extensions/widget_tester_extension.dart';
+import 'artist_card_test.mocks.dart';
+
+void main() {
+  Future<void> mountWithProvider(WidgetTester tester, Artist artist) async {
+    await tester.pumpAppWidget(
+      ChangeNotifierProvider<ArtistProvider>.value(
+        value: MockArtistProvider(),
+        child: ArtistRow(artist: artist, router: MockAppRouter()),
+      ),
+    );
+  }
+
+  testWidgets('shows Edit on long-press when canEdit', (tester) async {
+    final artist = Artist.fake(name: 'Editable', canEdit: true);
+    await mountWithProvider(tester, artist);
+
+    await tester.longPress(find.byType(ArtistRow));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Edit'), findsOneWidget);
+  });
+
+  testWidgets('no menu on long-press when canEdit is false', (tester) async {
+    final artist = Artist.fake(name: 'Read-only');
+    await mountWithProvider(tester, artist);
+
+    await tester.longPress(find.byType(ArtistRow));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Edit'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

Same pattern as #184 (albums), now for artists. Artists only expose `permissions.edit` on the server (no delete), so the menu is a single item.

### Model

- `Artist.fromJson` parses `permissions.edit` into a new `canEdit` flag. Defaults to `false` when the `permissions` key is absent (older koel) or its inner value isn't a bool. `Artist.merge` propagates `canEdit` from the remote.

### Provider

- New `ArtistProvider.update(artist, name)` that PUTs `/artists/:id`, mirrors the server's response onto the artist instance, and notifies. Artwork is out of scope here.

### Edit UI

- **Long-press** an `ArtistCard` or `ArtistRow` opens a frosted context menu with **Edit**, only when the user is permitted. Tap continues to navigate to the details screen. No-op when `canEdit` is false.
- **Edit** opens a new `showEditArtistDialog` with a single name field.

The long-press helper lives in `lib/ui/widgets/artist_actions_menu.dart` (`showArtistActionsMenu`), exported from `widgets.dart`.

## Test plan

- [x] `flutter test` — full suite green (267/267)
- [x] Model tests cover the three permissions parsing branches (present / missing / non-bool) and the new `Artist.merge` propagation case
- [x] `ArtistCard` and the new `ArtistRow` widget tests cover the two long-press cases on both surfaces (menu visible when `canEdit` / no menu when not)
- [x] `flutter analyze` clean on touched files (the two pre-existing warnings in `artist.dart` / `artists.dart` are out of scope)
- [ ] Smoke test against a 9.2.0 backend with two users; confirm long-press surfaces the menu for the owner and is a no-op for the other
- [ ] Smoke test the long-press on both the home/search artist cards and the artists-list artist rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Long-press on artist cards and rows to access edit context menu
- Edit artist names inline with form validation
- Permission-based controls restrict editing to authorized users only
- Real-time feedback confirms successful updates or displays error messages
- Haptic feedback enhances interaction during editing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->