### PR TITLE
Lift the empty Radio Stations content above visual center

### DIFF
--- a/lib/ui/screens/radio_stations.dart
+++ b/lib/ui/screens/radio_stations.dart
@@ -70,9 +70,13 @@ class _RadioStationsScreenState extends State<RadioStationsScreen> {
                     else if (stations.isEmpty && !_loading)
                       SliverFillRemaining(
                         hasScrollBody: false,
-                        child: Center(
+                        child: Align(
+                          // Slightly above visual center so the
+                          // mini-player + tab bar at the bottom don't
+                          // make the content read as 'sitting low'.
+                          alignment: const Alignment(0, -0.4),
                           child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
+                            mainAxisSize: MainAxisSize.min,
                             children: [
                               const Icon(
                                 CupertinoIcons.antenna_radiowaves_left_right,


### PR DESCRIPTION
Same UX fix as the empty-Podcasts polish in #186: a `Center` inside a `SliverFillRemaining` parks the content at 50% of the sliver's height, but the mini-player + tab bar cover the bottom of the sliver, so the empty state reads as 'sitting low' on the screen.

Switches to `Align(alignment: Alignment(0, -0.4))` to push the icon/headline/subtitle up to the optical center of the visible viewport.

No copy or icon changes — pure layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the positioning of the "No radio stations" empty state message to display higher on the screen for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->