### PR TITLE
Swallow unhandled error from fire-and-forget toggleFavorite (album)

### DIFF
--- a/lib/ui/screens/album_action_sheet.dart
+++ b/lib/ui/screens/album_action_sheet.dart
@@ -104,7 +104,16 @@ class _AlbumActionSheetState extends State<AlbumActionSheet> {
                                 : CupertinoIcons.star),
                             onTap: () {
                               Navigator.pop(context);
-                              albumProvider.toggleFavorite(album);
+                              // toggleFavorite rethrows on failure (after
+                              // rolling back the optimistic flip
+                              // internally). The sheet has just been
+                              // popped, so swallow here to avoid an
+                              // unhandled async error — the UI auto-
+                              // corrects from the rollback's
+                              // notifyListeners.
+                              albumProvider
+                                  .toggleFavorite(album)
+                                  .catchError((_) {});
                             },
                           ),
                           const PlayableQuickActionDivider(),


### PR DESCRIPTION
## Summary

Mirror of the same fix applied to the artist action sheet on #191. The Favorite quick action in `AlbumActionSheet` pops the sheet, then calls `albumProvider.toggleFavorite(album)` without awaiting. `toggleFavorite` rethrows on failure (after rolling back the optimistic flip internally), which becomes an unhandled async error.

The internal rollback already re-syncs the model and notifies listeners, so the UI auto-corrects on failure — no user feedback is needed at this point (the sheet is gone). Swallow with `.catchError((_) {})`.

## Test plan

- [x] `flutter test test/ui/screens/album_action_sheet_test.dart` — all 14 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the favorite quick action with improved error handling to ensure app stability and gracefully manage potential failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->