### PR TITLE
Show new overview sections on the Home screen

### DIFF
--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -6,10 +6,16 @@ class User {
   String name;
   String email;
 
+  /// The user's preferred order of Home screen blocks, by block id. Empty
+  /// when the server doesn't expose the preference (older API) or the user
+  /// never reordered the blocks.
+  final List<String> homeBlocksOrder;
+
   User({
     required this.id,
     required this.name,
     required this.email,
+    this.homeBlocksOrder = const [],
   });
 
   CachedNetworkImageProvider get avatar {
@@ -21,10 +27,15 @@ class User {
   }
 
   factory User.fromJson(Map<String, dynamic> json) {
+    final preferences = json['preferences'];
+    final order = preferences is Map ? preferences['home_blocks_order'] : null;
+
     return User(
       id: json['id'],
       name: json['name'],
       email: json['email'],
+      homeBlocksOrder:
+          order is List ? order.whereType<String>().toList() : const [],
     );
   }
 }

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -7,9 +7,11 @@ import 'package:app/utils/api_request.dart';
 import 'package:app/utils/preferences.dart' as preferences;
 
 class AuthProvider with StreamSubscriber {
-  late User _authUser;
+  User? _authUser;
 
-  User get authUser => _authUser;
+  User get authUser => _authUser!;
+
+  User? get maybeAuthUser => _authUser;
 
   static final _userLoggedIn = StreamController<User>.broadcast();
   static final userLoggedInStream = _userLoggedIn.stream;

--- a/lib/providers/overview_provider.dart
+++ b/lib/providers/overview_provider.dart
@@ -84,13 +84,13 @@ class OverviewProvider with ChangeNotifier, StreamSubscriber {
 
   List<Album> _parseAlbums(dynamic json) => _albumProvider.syncWithVault(
         ((json ?? const []) as List)
-            .map<Album>((j) => Album.fromJson(j))
+            .map<Album>((entry) => Album.fromJson(entry))
             .toList(),
       );
 
   List<Artist> _parseArtists(dynamic json) => _artistProvider.syncWithVault(
         ((json ?? const []) as List)
-            .map<Artist>((j) => Artist.fromJson(j))
+            .map<Artist>((entry) => Artist.fromJson(entry))
             .toList(),
       );
 

--- a/lib/providers/overview_provider.dart
+++ b/lib/providers/overview_provider.dart
@@ -13,9 +13,30 @@ class OverviewProvider with ChangeNotifier, StreamSubscriber {
   final mostPlayedSongs = <Playable>[];
   final recentlyAddedSongs = <Playable>[];
   final recentlyPlayedSongs = <Playable>[];
-  final recentlyAddedAlbums = <Album>[];
+  final leastPlayedSongs = <Playable>[];
+  final randomSongs = <Playable>[];
+  final similarSongs = <Playable>[];
   final mostPlayedAlbums = <Album>[];
+  final recentlyAddedAlbums = <Album>[];
+  final randomAlbums = <Album>[];
   final mostPlayedArtists = <Artist>[];
+  final recentlyAddedArtists = <Artist>[];
+  final randomArtists = <Artist>[];
+
+  late final List<List<dynamic>> _allSections = [
+    mostPlayedSongs,
+    recentlyAddedSongs,
+    recentlyPlayedSongs,
+    leastPlayedSongs,
+    randomSongs,
+    similarSongs,
+    mostPlayedAlbums,
+    recentlyAddedAlbums,
+    randomAlbums,
+    mostPlayedArtists,
+    recentlyAddedArtists,
+    randomArtists,
+  ];
 
   OverviewProvider({
     required playableProvider,
@@ -27,58 +48,55 @@ class OverviewProvider with ChangeNotifier, StreamSubscriber {
         _artistProvider = artistProvider,
         _recentlyPlayedProvider = recentlyPlayedProvider {
     subscribe(AuthProvider.userLoggedOutStream.listen((_) {
-      mostPlayedSongs.clear();
-      recentlyAddedSongs.clear();
-      recentlyPlayedSongs.clear();
-      mostPlayedAlbums.clear();
-      mostPlayedArtists.clear();
-
+      for (final section in _allSections) section.clear();
       notifyListeners();
     }));
   }
 
-  bool get isEmpty =>
-      mostPlayedSongs.isEmpty &&
-      recentlyAddedSongs.isEmpty &&
-      recentlyPlayedSongs.isEmpty &&
-      mostPlayedAlbums.isEmpty &&
-      mostPlayedArtists.isEmpty;
+  bool get isEmpty => _allSections.every((section) => section.isEmpty);
 
   Future<void> refresh() async {
     final Map<String, dynamic> response = await get('overview');
 
-    mostPlayedSongs
-      ..clear()
-      ..addAll(_playableProvider.parseFromJson(response['most_played_songs']));
+    _fill(mostPlayedSongs, _parseSongs(response['most_played_songs']));
+    _fill(recentlyAddedSongs, _parseSongs(response['recently_added_songs']));
+    _fill(recentlyPlayedSongs, _parseSongs(response['recently_played_songs']));
+    _fill(leastPlayedSongs, _parseSongs(response['least_played_songs']));
+    _fill(randomSongs, _parseSongs(response['random_songs']));
+    _fill(similarSongs, _parseSongs(response['similar_songs']));
 
-    recentlyAddedSongs
-      ..clear()
-      ..addAll(
-          _playableProvider.parseFromJson(response['recently_added_songs']));
+    _fill(mostPlayedAlbums, _parseAlbums(response['most_played_albums']));
+    _fill(recentlyAddedAlbums, _parseAlbums(response['recently_added_albums']));
+    _fill(randomAlbums, _parseAlbums(response['random_albums']));
 
-    recentlyPlayedSongs
-      ..clear()
-      ..addAll(
-          _playableProvider.parseFromJson(response['recently_played_songs']));
+    _fill(mostPlayedArtists, _parseArtists(response['most_played_artists']));
+    _fill(recentlyAddedArtists,
+        _parseArtists(response['recently_added_artists']));
+    _fill(randomArtists, _parseArtists(response['random_artists']));
 
     _recentlyPlayedProvider.seed(recentlyPlayedSongs);
 
-    final _mostPlayedAlbums = response['most_played_albums']
-        .map<Album>((j) => Album.fromJson(j))
-        .toList();
-
-    mostPlayedAlbums
-      ..clear()
-      ..addAll(_albumProvider.syncWithVault(_mostPlayedAlbums));
-
-    final _mostPlayedArtist = response['most_played_artists']
-        .map<Artist>((j) => Artist.fromJson(j))
-        .toList();
-
-    mostPlayedArtists
-      ..clear()
-      ..addAll(_artistProvider.syncWithVault(_mostPlayedArtist));
-
     notifyListeners();
+  }
+
+  List<Playable> _parseSongs(dynamic json) =>
+      _playableProvider.parseFromJson(json ?? const []);
+
+  List<Album> _parseAlbums(dynamic json) => _albumProvider.syncWithVault(
+        ((json ?? const []) as List)
+            .map<Album>((j) => Album.fromJson(j))
+            .toList(),
+      );
+
+  List<Artist> _parseArtists(dynamic json) => _artistProvider.syncWithVault(
+        ((json ?? const []) as List)
+            .map<Artist>((j) => Artist.fromJson(j))
+            .toList(),
+      );
+
+  void _fill<T>(List<T> target, List<T> source) {
+    target
+      ..clear()
+      ..addAll(source);
   }
 }

--- a/lib/ui/screens/home.dart
+++ b/lib/ui/screens/home.dart
@@ -46,6 +46,52 @@ class _HomeScreenState extends State<HomeScreen> {
     }
   }
 
+  Widget _songBlock(String heading, List<Playable> songs) {
+    return HorizontalCardScroller(
+      headingText: heading,
+      cards: <Widget>[
+        ...songs.map((playable) => SongCard(playable: playable)),
+        PlaceholderCard(
+          icon: CupertinoIcons.music_note,
+          onPressed: () => Navigator.of(context).push(
+            CupertinoPageRoute(builder: (_) => SongsScreen()),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _albumBlock(String heading, List<Album> albums) {
+    return HorizontalCardScroller(
+      headingText: heading,
+      cards: <Widget>[
+        ...albums.map((album) => AlbumCard(album: album)),
+        PlaceholderCard(
+          icon: CupertinoIcons.music_albums,
+          onPressed: () => Navigator.of(context).push(
+            CupertinoPageRoute(builder: (_) => AlbumsScreen()),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _artistBlock(String heading, List<Artist> artists) {
+    return HorizontalCardScroller(
+      headingText: heading,
+      cards: <Widget>[
+        ...artists.map((artist) => ArtistCard(artist: artist)),
+        PlaceholderCard(
+          icon: CupertinoIcons.music_mic,
+          circular: true,
+          onPressed: () => Navigator.of(context).push(
+            CupertinoPageRoute(builder: (_) => const ArtistsScreen()),
+          ),
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Consumer<OverviewProvider>(
@@ -53,55 +99,35 @@ class _HomeScreenState extends State<HomeScreen> {
         if (_loading) return const HomeScreenPlaceholder();
         if (_errored) return OopsBox(onRetry: fetchData);
 
+        final op = overviewProvider;
         final blocks = <Widget>[
-          if (overviewProvider.mostPlayedSongs.isNotEmpty)
-            HorizontalCardScroller(
-              headingText: 'Most played',
-              cards: <Widget>[
-                ...overviewProvider.mostPlayedSongs
-                    .map((playable) => SongCard(playable: playable)),
-                PlaceholderCard(
-                  icon: CupertinoIcons.music_note,
-                  onPressed: () => Navigator.of(context).push(
-                    CupertinoPageRoute(builder: (_) => SongsScreen()),
-                  ),
-                ),
-              ],
-            ),
-          if (overviewProvider.mostPlayedAlbums.isNotEmpty)
-            HorizontalCardScroller(
-              headingText: 'Top albums',
-              cards: <Widget>[
-                ...overviewProvider.mostPlayedAlbums
-                    .map((album) => AlbumCard(album: album)),
-                PlaceholderCard(
-                  icon: CupertinoIcons.music_albums,
-                  onPressed: () => Navigator.of(context).push(
-                    CupertinoPageRoute(builder: (_) => AlbumsScreen()),
-                  ),
-                ),
-              ],
-            ),
-          if (overviewProvider.mostPlayedArtists.isNotEmpty)
-            HorizontalCardScroller(
-              headingText: 'Top artists',
-              cards: <Widget>[
-                ...overviewProvider.mostPlayedArtists
-                    .map((artist) => ArtistCard(artist: artist)),
-                PlaceholderCard(
-                  icon: CupertinoIcons.music_mic,
-                  circular: true,
-                  onPressed: () => Navigator.of(context).push(
-                    CupertinoPageRoute(builder: (_) => const ArtistsScreen()),
-                  ),
-                ),
-              ],
-            ),
+          if (op.recentlyAddedAlbums.isNotEmpty)
+            _albumBlock('Latest Albums', op.recentlyAddedAlbums),
+          if (op.similarSongs.isNotEmpty)
+            _songBlock('You Might Also Like', op.similarSongs),
+          if (op.mostPlayedAlbums.isNotEmpty)
+            _albumBlock('Top Albums', op.mostPlayedAlbums),
+          if (op.mostPlayedSongs.isNotEmpty)
+            _songBlock('Most Played', op.mostPlayedSongs),
+          if (op.mostPlayedArtists.isNotEmpty)
+            _artistBlock('Top Artists', op.mostPlayedArtists),
+          if (op.recentlyAddedSongs.isNotEmpty)
+            _songBlock('New Songs', op.recentlyAddedSongs),
+          if (op.recentlyAddedArtists.isNotEmpty)
+            _artistBlock('New Artists', op.recentlyAddedArtists),
+          if (op.leastPlayedSongs.isNotEmpty)
+            _songBlock('Hidden Gems', op.leastPlayedSongs),
+          if (op.randomSongs.isNotEmpty)
+            _songBlock('Random Songs', op.randomSongs),
+          if (op.randomAlbums.isNotEmpty)
+            _albumBlock('Random Albums', op.randomAlbums),
+          if (op.randomArtists.isNotEmpty)
+            _artistBlock('Random Artists', op.randomArtists),
         ]
             .map(
-              (widget) => Padding(
+              (block) => Padding(
                 padding: const EdgeInsets.symmetric(vertical: 16),
-                child: widget,
+                child: block,
               ),
             )
             .toList();

--- a/lib/ui/screens/home.dart
+++ b/lib/ui/screens/home.dart
@@ -19,6 +19,36 @@ class HomeScreen extends StatefulWidget {
   State<StatefulWidget> createState() => _HomeScreenState();
 }
 
+class _HomeBlock {
+  final String id;
+  final Widget widget;
+
+  const _HomeBlock(this.id, this.widget);
+}
+
+/// Reorders [blocks] to honour the user's saved [savedOrder] (a list of block
+/// ids). Blocks named in [savedOrder] come first in that order; the rest keep
+/// their default relative order. Ids in [savedOrder] with no matching block are
+/// ignored. Returns [blocks] unchanged when no preference is saved.
+List<T> orderByHomeBlocksPreference<T>(
+  List<T> blocks,
+  String Function(T) idOf,
+  List<String> savedOrder,
+) {
+  if (savedOrder.isEmpty) return blocks;
+
+  final indexed = blocks.asMap().entries.toList();
+
+  int sortKey(MapEntry<int, T> entry) {
+    final saved = savedOrder.indexOf(idOf(entry.value));
+    return saved == -1 ? savedOrder.length + entry.key : saved;
+  }
+
+  indexed.sort((a, b) => sortKey(a).compareTo(sortKey(b)));
+
+  return indexed.map((entry) => entry.value).toList();
+}
+
 class _HomeScreenState extends State<HomeScreen> {
   var _loading = false;
   var _errored = false;
@@ -100,34 +130,58 @@ class _HomeScreenState extends State<HomeScreen> {
         if (_errored) return OopsBox(onRetry: fetchData);
 
         final op = overviewProvider;
-        final blocks = <Widget>[
+
+        // Default order mirrors koel web's default home layout (minus the
+        // recently-played section, which the mobile app pins to the top).
+        final defaultBlocks = <_HomeBlock>[
           if (op.recentlyAddedAlbums.isNotEmpty)
-            _albumBlock('Latest Albums', op.recentlyAddedAlbums),
+            _HomeBlock('recently-added-albums',
+                _albumBlock('Latest Albums', op.recentlyAddedAlbums)),
           if (op.similarSongs.isNotEmpty)
-            _songBlock('You Might Also Like', op.similarSongs),
+            _HomeBlock('similar-songs',
+                _songBlock('You Might Also Like', op.similarSongs)),
           if (op.mostPlayedAlbums.isNotEmpty)
-            _albumBlock('Top Albums', op.mostPlayedAlbums),
+            _HomeBlock('most-played-albums',
+                _albumBlock('Top Albums', op.mostPlayedAlbums)),
           if (op.mostPlayedSongs.isNotEmpty)
-            _songBlock('Most Played', op.mostPlayedSongs),
+            _HomeBlock('most-played-songs',
+                _songBlock('Most Played', op.mostPlayedSongs)),
           if (op.mostPlayedArtists.isNotEmpty)
-            _artistBlock('Top Artists', op.mostPlayedArtists),
+            _HomeBlock('most-played-artists',
+                _artistBlock('Top Artists', op.mostPlayedArtists)),
           if (op.recentlyAddedSongs.isNotEmpty)
-            _songBlock('New Songs', op.recentlyAddedSongs),
+            _HomeBlock('recently-added-songs',
+                _songBlock('New Songs', op.recentlyAddedSongs)),
           if (op.recentlyAddedArtists.isNotEmpty)
-            _artistBlock('New Artists', op.recentlyAddedArtists),
+            _HomeBlock('recently-added-artists',
+                _artistBlock('New Artists', op.recentlyAddedArtists)),
           if (op.leastPlayedSongs.isNotEmpty)
-            _songBlock('Hidden Gems', op.leastPlayedSongs),
+            _HomeBlock('least-played-songs',
+                _songBlock('Hidden Gems', op.leastPlayedSongs)),
           if (op.randomSongs.isNotEmpty)
-            _songBlock('Random Songs', op.randomSongs),
+            _HomeBlock(
+                'random-songs', _songBlock('Random Songs', op.randomSongs)),
           if (op.randomAlbums.isNotEmpty)
-            _albumBlock('Random Albums', op.randomAlbums),
+            _HomeBlock('random-albums',
+                _albumBlock('Random Albums', op.randomAlbums)),
           if (op.randomArtists.isNotEmpty)
-            _artistBlock('Random Artists', op.randomArtists),
-        ]
+            _HomeBlock('random-artists',
+                _artistBlock('Random Artists', op.randomArtists)),
+        ];
+
+        final savedOrder =
+            context.read<AuthProvider>().maybeAuthUser?.homeBlocksOrder ??
+                const <String>[];
+
+        final blocks = orderByHomeBlocksPreference<_HomeBlock>(
+          defaultBlocks,
+          (block) => block.id,
+          savedOrder,
+        )
             .map(
               (block) => Padding(
                 padding: const EdgeInsets.symmetric(vertical: 16),
-                child: block,
+                child: block.widget,
               ),
             )
             .toList();

--- a/lib/ui/screens/home.dart
+++ b/lib/ui/screens/home.dart
@@ -91,11 +91,12 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
-  Widget _albumBlock(String heading, List<Album> albums) {
+  Widget _albumBlock(String heading, List<Album> albums, Set seenAlbumIds) {
     return HorizontalCardScroller(
       headingText: heading,
       cards: <Widget>[
-        ...albums.map((album) => AlbumCard(album: album)),
+        ...albums.map((album) =>
+            AlbumCard(album: album, asHero: seenAlbumIds.add(album.id))),
         PlaceholderCard(
           icon: CupertinoIcons.music_albums,
           onPressed: () => Navigator.of(context).push(
@@ -106,11 +107,12 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
-  Widget _artistBlock(String heading, List<Artist> artists) {
+  Widget _artistBlock(String heading, List<Artist> artists, Set seenArtistIds) {
     return HorizontalCardScroller(
       headingText: heading,
       cards: <Widget>[
-        ...artists.map((artist) => ArtistCard(artist: artist)),
+        ...artists.map((artist) =>
+            ArtistCard(artist: artist, asHero: seenArtistIds.add(artist.id))),
         PlaceholderCard(
           icon: CupertinoIcons.music_mic,
           circular: true,
@@ -131,30 +133,38 @@ class _HomeScreenState extends State<HomeScreen> {
 
         final op = overviewProvider;
 
+        // Grant the hero animation to only the first card per entity, so the
+        // same album/artist appearing in several blocks doesn't produce
+        // duplicate hero tags within the route.
+        final seenAlbumIds = <dynamic>{};
+        final seenArtistIds = <dynamic>{};
+
         // Default order mirrors koel web's default home layout (minus the
         // recently-played section, which the mobile app pins to the top).
         final defaultBlocks = <_HomeBlock>[
           if (op.recentlyAddedAlbums.isNotEmpty)
             _HomeBlock('recently-added-albums',
-                _albumBlock('Latest Albums', op.recentlyAddedAlbums)),
+                _albumBlock('Latest Albums', op.recentlyAddedAlbums, seenAlbumIds)),
           if (op.similarSongs.isNotEmpty)
             _HomeBlock('similar-songs',
                 _songBlock('You Might Also Like', op.similarSongs)),
           if (op.mostPlayedAlbums.isNotEmpty)
             _HomeBlock('most-played-albums',
-                _albumBlock('Top Albums', op.mostPlayedAlbums)),
+                _albumBlock('Top Albums', op.mostPlayedAlbums, seenAlbumIds)),
           if (op.mostPlayedSongs.isNotEmpty)
             _HomeBlock('most-played-songs',
                 _songBlock('Most Played', op.mostPlayedSongs)),
           if (op.mostPlayedArtists.isNotEmpty)
             _HomeBlock('most-played-artists',
-                _artistBlock('Top Artists', op.mostPlayedArtists)),
+                _artistBlock('Top Artists', op.mostPlayedArtists, seenArtistIds)),
           if (op.recentlyAddedSongs.isNotEmpty)
             _HomeBlock('recently-added-songs',
                 _songBlock('New Songs', op.recentlyAddedSongs)),
           if (op.recentlyAddedArtists.isNotEmpty)
-            _HomeBlock('recently-added-artists',
-                _artistBlock('New Artists', op.recentlyAddedArtists)),
+            _HomeBlock(
+                'recently-added-artists',
+                _artistBlock(
+                    'New Artists', op.recentlyAddedArtists, seenArtistIds)),
           if (op.leastPlayedSongs.isNotEmpty)
             _HomeBlock('least-played-songs',
                 _songBlock('Hidden Gems', op.leastPlayedSongs)),
@@ -163,10 +173,10 @@ class _HomeScreenState extends State<HomeScreen> {
                 'random-songs', _songBlock('Random Songs', op.randomSongs)),
           if (op.randomAlbums.isNotEmpty)
             _HomeBlock('random-albums',
-                _albumBlock('Random Albums', op.randomAlbums)),
+                _albumBlock('Random Albums', op.randomAlbums, seenAlbumIds)),
           if (op.randomArtists.isNotEmpty)
             _HomeBlock('random-artists',
-                _artistBlock('Random Artists', op.randomArtists)),
+                _artistBlock('Random Artists', op.randomArtists, seenArtistIds)),
         ];
 
         final savedOrder =

--- a/lib/ui/screens/home.dart
+++ b/lib/ui/screens/home.dart
@@ -44,7 +44,7 @@ List<T> orderByHomeBlocksPreference<T>(
     return saved == -1 ? savedOrder.length + entry.key : saved;
   }
 
-  indexed.sort((a, b) => sortKey(a).compareTo(sortKey(b)));
+  indexed.sort((left, right) => sortKey(left).compareTo(sortKey(right)));
 
   return indexed.map((entry) => entry.value).toList();
 }

--- a/lib/ui/widgets/album_card.dart
+++ b/lib/ui/widgets/album_card.dart
@@ -10,10 +10,16 @@ class AlbumCard extends StatefulWidget {
   final Album album;
   final AppRouter router;
 
+  /// Whether the thumbnail animates to the details screen as a Hero. Set to
+  /// false when the same album may appear more than once in a route (e.g.
+  /// across Home blocks), so hero tags stay unique.
+  final bool asHero;
+
   AlbumCard({
     Key? key,
     required this.album,
     this.router = const AppRouter(),
+    this.asHero = true,
   }) : super(key: key);
 
   @override
@@ -42,7 +48,8 @@ class _AlbumCardState extends State<AlbumCard> {
           opacity: _opacity,
           child: Column(
             children: <Widget>[
-              AlbumArtistThumbnail.md(entity: widget.album, asHero: true),
+              AlbumArtistThumbnail.md(
+                  entity: widget.album, asHero: widget.asHero),
               const SizedBox(height: 12),
               SizedBox(
                 width: _cardWidth,

--- a/lib/ui/widgets/artist_card.dart
+++ b/lib/ui/widgets/artist_card.dart
@@ -10,10 +10,16 @@ class ArtistCard extends StatefulWidget {
   final Artist artist;
   final AppRouter router;
 
+  /// Whether the thumbnail animates to the details screen as a Hero. Set to
+  /// false when the same artist may appear more than once in a route (e.g.
+  /// across Home blocks), so hero tags stay unique.
+  final bool asHero;
+
   ArtistCard({
     Key? key,
     required this.artist,
     this.router = const AppRouter(),
+    this.asHero = true,
   }) : super(key: key);
 
   @override
@@ -43,7 +49,8 @@ class _ArtistCardState extends State<ArtistCard> {
           opacity: _opacity,
           child: Column(
             children: <Widget>[
-              AlbumArtistThumbnail.md(entity: widget.artist, asHero: true),
+              AlbumArtistThumbnail.md(
+                  entity: widget.artist, asHero: widget.asHero),
               const SizedBox(height: 12),
               SizedBox(
                 width: _cardWidth,

--- a/test/models/user_test.dart
+++ b/test/models/user_test.dart
@@ -1,0 +1,36 @@
+import 'package:app/models/user.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Map<String, dynamic> baseJson({dynamic preferences}) => {
+        'id': 'user-1',
+        'name': 'Jane',
+        'email': 'jane@koel.test',
+        if (preferences != null) 'preferences': preferences,
+      };
+
+  test('parses home_blocks_order from preferences', () {
+    final user = User.fromJson(baseJson(preferences: {
+      'home_blocks_order': ['random-songs', 'most-played-albums'],
+    }));
+
+    expect(user.homeBlocksOrder, ['random-songs', 'most-played-albums']);
+  });
+
+  test('defaults home_blocks_order to empty when absent (older API)', () {
+    expect(User.fromJson(baseJson()).homeBlocksOrder, isEmpty);
+    expect(
+      User.fromJson(baseJson(preferences: {'something_else': true}))
+          .homeBlocksOrder,
+      isEmpty,
+    );
+  });
+
+  test('keeps only string entries in home_blocks_order', () {
+    final user = User.fromJson(baseJson(preferences: {
+      'home_blocks_order': ['random-songs', 42, null, 'top-albums'],
+    }));
+
+    expect(user.homeBlocksOrder, ['random-songs', 'top-albums']);
+  });
+}

--- a/test/providers/overview_provider_test.dart
+++ b/test/providers/overview_provider_test.dart
@@ -1,0 +1,121 @@
+import 'package:app/models/song.dart';
+import 'package:app/providers/album_provider.dart';
+import 'package:app/providers/artist_provider.dart';
+import 'package:app/providers/overview_provider.dart';
+import 'package:app/providers/playable_provider.dart';
+import 'package:app/providers/recently_played_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/api_test_setup.dart';
+
+void main() {
+  late OverviewProvider overview;
+  late CapturingClient client;
+  var _seq = 0;
+
+  List<Map<String, dynamic>> songs(int count) =>
+      List.generate(count, (_) => Song.fake().toJson());
+
+  List<Map<String, dynamic>> albums(int count) => List.generate(count, (_) {
+        final id = 'album-${_seq++}';
+        return {
+          'id': id,
+          'name': 'Album $id',
+          'cover': null,
+          'artist_id': 'artist-$id',
+          'artist_name': 'Artist $id',
+          'year': null,
+        };
+      });
+
+  List<Map<String, dynamic>> artists(int count) => List.generate(count, (_) {
+        final id = 'artist-${_seq++}';
+        return {'id': id, 'name': 'Artist $id', 'image': null};
+      });
+
+  setUpAll(() async => await initApiTestEnvironment());
+
+  setUp(() {
+    _seq = 0;
+    final playableProvider = PlayableProvider();
+    overview = OverviewProvider(
+      playableProvider: playableProvider,
+      albumProvider: AlbumProvider(),
+      artistProvider: ArtistProvider(),
+      recentlyPlayedProvider:
+          RecentlyPlayedProvider(playableProvider: playableProvider),
+    );
+    client = CapturingClient();
+    client.install();
+    setUpApiTest();
+  });
+
+  tearDown(tearDownApiTest);
+
+  test('refresh populates every overview section', () async {
+    client.willReturn(json: {
+      'most_played_songs': songs(3),
+      'recently_added_songs': songs(2),
+      'recently_played_songs': songs(4),
+      'least_played_songs': songs(1),
+      'random_songs': songs(5),
+      'similar_songs': songs(6),
+      'most_played_albums': albums(3),
+      'recently_added_albums': albums(2),
+      'random_albums': albums(4),
+      'most_played_artists': artists(3),
+      'recently_added_artists': artists(2),
+      'random_artists': artists(4),
+    });
+
+    await overview.refresh();
+
+    expect(overview.mostPlayedSongs, hasLength(3));
+    expect(overview.recentlyAddedSongs, hasLength(2));
+    expect(overview.recentlyPlayedSongs, hasLength(4));
+    expect(overview.leastPlayedSongs, hasLength(1));
+    expect(overview.randomSongs, hasLength(5));
+    expect(overview.similarSongs, hasLength(6));
+    expect(overview.mostPlayedAlbums, hasLength(3));
+    expect(overview.recentlyAddedAlbums, hasLength(2));
+    expect(overview.randomAlbums, hasLength(4));
+    expect(overview.mostPlayedArtists, hasLength(3));
+    expect(overview.recentlyAddedArtists, hasLength(2));
+    expect(overview.randomArtists, hasLength(4));
+  });
+
+  test('refresh leaves sections empty when an older API omits them', () async {
+    client.willReturn(json: {
+      'most_played_songs': songs(2),
+      'recently_played_songs': songs(1),
+      'most_played_albums': albums(2),
+      'most_played_artists': artists(2),
+    });
+
+    await overview.refresh();
+
+    expect(overview.mostPlayedSongs, hasLength(2));
+    expect(overview.recentlyPlayedSongs, hasLength(1));
+    expect(overview.mostPlayedAlbums, hasLength(2));
+    expect(overview.mostPlayedArtists, hasLength(2));
+
+    expect(overview.recentlyAddedSongs, isEmpty);
+    expect(overview.leastPlayedSongs, isEmpty);
+    expect(overview.randomSongs, isEmpty);
+    expect(overview.similarSongs, isEmpty);
+    expect(overview.recentlyAddedAlbums, isEmpty);
+    expect(overview.randomAlbums, isEmpty);
+    expect(overview.recentlyAddedArtists, isEmpty);
+    expect(overview.randomArtists, isEmpty);
+
+    expect(overview.isEmpty, isFalse);
+  });
+
+  test('isEmpty is true when the API returns nothing', () async {
+    client.willReturn(json: {});
+
+    await overview.refresh();
+
+    expect(overview.isEmpty, isTrue);
+  });
+}

--- a/test/ui/screens/home_block_order_test.dart
+++ b/test/ui/screens/home_block_order_test.dart
@@ -1,0 +1,47 @@
+import 'package:app/ui/screens/home.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  String idOf(String id) => id;
+
+  test('keeps the default order when no preference is saved', () {
+    final ordered = orderByHomeBlocksPreference(
+      ['a', 'b', 'c'],
+      idOf,
+      const [],
+    );
+
+    expect(ordered, ['a', 'b', 'c']);
+  });
+
+  test('moves saved blocks to the front in the saved order', () {
+    final ordered = orderByHomeBlocksPreference(
+      ['a', 'b', 'c', 'd'],
+      idOf,
+      ['c', 'a'],
+    );
+
+    // c, a first (saved order), then the rest keep their default order.
+    expect(ordered, ['c', 'a', 'b', 'd']);
+  });
+
+  test('ignores saved ids that have no matching block', () {
+    final ordered = orderByHomeBlocksPreference(
+      ['a', 'b'],
+      idOf,
+      ['x', 'b', 'y'],
+    );
+
+    expect(ordered, ['b', 'a']);
+  });
+
+  test('preserves the default order of blocks absent from the preference', () {
+    final ordered = orderByHomeBlocksPreference(
+      ['a', 'b', 'c', 'd', 'e'],
+      idOf,
+      ['e'],
+    );
+
+    expect(ordered, ['e', 'a', 'b', 'c', 'd']);
+  });
+}

--- a/test/ui/widgets/card_hero_test.dart
+++ b/test/ui/widgets/card_hero_test.dart
@@ -1,0 +1,79 @@
+import 'package:app/models/album.dart';
+import 'package:app/models/artist.dart';
+import 'package:app/providers/album_provider.dart';
+import 'package:app/providers/artist_provider.dart';
+import 'package:app/ui/widgets/album_artist_thumbnail.dart';
+import 'package:app/ui/widgets/album_card.dart';
+import 'package:app/ui/widgets/artist_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import '../../extensions/widget_tester_extension.dart';
+
+void main() {
+  Finder heroWithTag(Object tag) =>
+      find.byWidgetPredicate((widget) => widget is Hero && widget.tag == tag);
+
+  testWidgets('an album card omits the hero when asHero is false',
+      (tester) async {
+    final album = Album.fake();
+
+    await tester.pumpAppWidget(
+      ChangeNotifierProvider<AlbumProvider>(
+        create: (_) => AlbumProvider(),
+        child: AlbumCard(album: album, asHero: false),
+      ),
+    );
+
+    expect(heroWithTag(AlbumArtistThumbnail.tagForEntity(album)), findsNothing);
+  });
+
+  testWidgets('a repeated album yields a single hero tag across cards',
+      (tester) async {
+    final album = Album.fake();
+
+    await tester.pumpAppWidget(
+      ChangeNotifierProvider<AlbumProvider>(
+        create: (_) => AlbumProvider(),
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              AlbumCard(album: album, asHero: true),
+              AlbumCard(album: album, asHero: false),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      heroWithTag(AlbumArtistThumbnail.tagForEntity(album)),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('a repeated artist yields a single hero tag across cards',
+      (tester) async {
+    final artist = Artist.fake();
+
+    await tester.pumpAppWidget(
+      ChangeNotifierProvider<ArtistProvider>(
+        create: (_) => ArtistProvider(),
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              ArtistCard(artist: artist, asHero: true),
+              ArtistCard(artist: artist, asHero: false),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      heroWithTag(AlbumArtistThumbnail.tagForEntity(artist)),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
koel's overview API (`FetchOverviewController`) now returns more than most-played/top-albums/top-artists. This surfaces the rest on the Home screen.

## New sections rendered
Latest Albums, You Might Also Like (similar songs), New Songs, New Artists, Hidden Gems (least played), Random Songs, Random Albums, Random Artists — alongside the existing Recently Played, Most Played, Top Albums, Top Artists.

## Block order
Defaults to koel web's default home layout. If the user has reordered their blocks on the web, that preference (`home_blocks_order`, returned via `GET me`) is honoured: saved blocks come first in the saved order, the rest keep the default order. The mobile app keeps the Recently Played section pinned at the top (it's a distinct list, not a card scroller), so its position in the saved order is ignored.

## Backward compatibility
Older API versions return neither the new overview keys nor the preference. `OverviewProvider` parses each section with a null-safe fallback (`json ?? const []`), the Home screen only renders a block when its list is non-empty, and an empty/absent `home_blocks_order` falls back to the default order. So on an older server nothing new appears and ordering is unchanged.

## Notes
- Extracted `_songBlock`/`_albumBlock`/`_artistBlock` helpers to avoid duplicating card-scroller boilerplate across 11 blocks.
- Block reordering UI (a web feature) is out of scope — we only honour a preference already saved on the web.

## Tests
- `overview_provider_test.dart` — every section populates from a full response; omitted keys (older API) stay empty; `isEmpty` is true for `{}`.
- `home_block_order_test.dart` — default order with no preference; saved blocks move to front; unknown saved ids ignored; unsaved blocks keep default order.
- `user_test.dart` — `home_blocks_order` parsed from preferences; defaults to empty when absent; non-string entries dropped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the home screen with additional discovery sections (recently added, similar, hidden gems/least played, and random) across songs, albums, and artists.
  * Added user-configurable Home block ordering using saved preferences.
  * Added an `asHero` option to album/artist cards to control Hero animation behavior.
* **Bug Fixes**
  * Improved logout behavior to fully clear all overview data before refreshing the UI.
* **Tests**
  * Added coverage for overview refresh/empty states, preference parsing, block ordering, and Hero rendering rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->