### PR TITLE
Bump version to 2.2.9 (build 47)

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -365,7 +365,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 47;
 				DEVELOPMENT_TEAM = PTBU9CDS3L;
 				ENABLE_BITCODE = NO;
 				FLUTTER_BUILD_NAME = 2.1.0;
@@ -378,7 +378,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.5;
+				MARKETING_VERSION = 2.2.9;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.koel.koel;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -510,7 +510,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 47;
 				DEVELOPMENT_TEAM = PTBU9CDS3L;
 				ENABLE_BITCODE = NO;
 				FLUTTER_BUILD_NAME = 2.1.0;
@@ -523,7 +523,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.5;
+				MARKETING_VERSION = 2.2.9;
 				PRODUCT_BUNDLE_IDENTIFIER = debug.dev.koel.koel;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -544,7 +544,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 47;
 				DEVELOPMENT_TEAM = PTBU9CDS3L;
 				ENABLE_BITCODE = NO;
 				FLUTTER_BUILD_NAME = 2.1.0;
@@ -557,7 +557,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.5;
+				MARKETING_VERSION = 2.2.9;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.koel.koel;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 2.2.8+45
+version: 2.2.9+47
 
 environment:
   sdk: ">=2.17.0-0 <3.0.0"


### PR DESCRIPTION
Realigns the version fields so the repo matches what's shipping.

- `MARKETING_VERSION` / pubspec version → **2.2.9** (App Store Connect's latest released version was 2.2.8)
- `CURRENT_PROJECT_VERSION` / pubspec build → **47** (last uploaded build was 46)

The iOS project fields had drifted well behind reality (`2.2.5` / `33`); pubspec was closer (`2.2.8+45`). This is the version the 2.2.9 IPA was built and uploaded with.
