### PR TITLE
Respect the custom order of playlists and favorites

### DIFF
--- a/lib/extensions/playable_list.dart
+++ b/lib/extensions/playable_list.dart
@@ -14,7 +14,13 @@ extension PlayableListExtension on List<Playable> {
   }
 
   List<Playable> $sort(PlayableSortConfig config) {
-    return this
+    // 'position' keeps the order the server returned (e.g. a playlist's own
+    // order defined on the web), reversible via the sort direction.
+    if (config.field == 'position') {
+      return config.order == SortOrder.asc ? [...this] : reversed.toList();
+    }
+
+    return [...this]
       ..sort((a, b) => config.order == SortOrder.asc
           ? a.valueToCompare(config).compareTo(b.valueToCompare(config))
           : b.valueToCompare(config).compareTo(a.valueToCompare(config)));

--- a/lib/ui/screens/favorites.dart
+++ b/lib/ui/screens/favorites.dart
@@ -5,6 +5,7 @@ import 'package:app/extensions/extensions.dart';
 import 'package:app/providers/providers.dart';
 import 'package:app/ui/placeholders/placeholders.dart';
 import 'package:app/ui/widgets/widgets.dart';
+import 'package:app/utils/features.dart';
 import 'package:app/values/values.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart' hide AppBar;
@@ -50,9 +51,13 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final supportsCustomOrder = Feature.customFavoritesOrder.isSupported();
     var sortConfig = AppState.get(
       'favorites.sort',
-      PlayableSortConfig(field: 'position', order: SortOrder.asc),
+      PlayableSortConfig(
+        field: supportsCustomOrder ? 'position' : 'title',
+        order: SortOrder.asc,
+      ),
     )!;
 
     final emptyWidget = SliverFillRemaining(
@@ -139,7 +144,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
                             actions: [
                               SortButton(
                                 fields: [
-                                  'position',
+                                  if (supportsCustomOrder) 'position',
                                   'title',
                                   'artist_name',
                                   'created_at'

--- a/lib/ui/screens/favorites.dart
+++ b/lib/ui/screens/favorites.dart
@@ -52,7 +52,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
   Widget build(BuildContext context) {
     var sortConfig = AppState.get(
       'favorites.sort',
-      PlayableSortConfig(field: 'title', order: SortOrder.asc),
+      PlayableSortConfig(field: 'position', order: SortOrder.asc),
     )!;
 
     final emptyWidget = SliverFillRemaining(
@@ -138,7 +138,12 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
                                 provider.playables),
                             actions: [
                               SortButton(
-                                fields: ['title', 'artist_name', 'created_at'],
+                                fields: [
+                                  'position',
+                                  'title',
+                                  'artist_name',
+                                  'created_at'
+                                ],
                                 currentField: sortConfig.field,
                                 currentOrder: sortConfig.order,
                                 onMenuItemSelected: (_sortConfig) {

--- a/lib/ui/screens/playlist_details.dart
+++ b/lib/ui/screens/playlist_details.dart
@@ -57,7 +57,7 @@ class _PlaylistDetailsScreen extends State<PlaylistDetailsScreen> {
     final playlist = ModalRoute.of(context)!.settings.arguments as Playlist;
     var sortConfig = AppState.get(
       'playlist.sort',
-      PlayableSortConfig(field: 'title', order: SortOrder.asc),
+      PlayableSortConfig(field: 'position', order: SortOrder.asc),
     )!;
 
     return Scaffold(
@@ -98,7 +98,7 @@ class _PlaylistDetailsScreen extends State<PlaylistDetailsScreen> {
                     backgroundImage: _buildBackgroundImage(playlist, playables),
                     actions: [
                       SortButton(
-                        fields: ['title', 'artist_name', 'created_at'],
+                        fields: ['position', 'title', 'artist_name', 'created_at'],
                         currentField: sortConfig.field,
                         currentOrder: sortConfig.order,
                         onMenuItemSelected: (_sortConfig) {

--- a/lib/ui/screens/playlist_details.dart
+++ b/lib/ui/screens/playlist_details.dart
@@ -5,6 +5,7 @@ import 'package:app/models/models.dart';
 import 'package:app/providers/providers.dart';
 import 'package:app/ui/placeholders/placeholders.dart';
 import 'package:app/ui/widgets/widgets.dart';
+import 'package:app/utils/features.dart';
 import 'package:app/values/values.dart';
 
 import 'package:cached_network_image/cached_network_image.dart';
@@ -55,9 +56,13 @@ class _PlaylistDetailsScreen extends State<PlaylistDetailsScreen> {
   @override
   Widget build(BuildContext context) {
     final playlist = ModalRoute.of(context)!.settings.arguments as Playlist;
+    final supportsCustomOrder = Feature.customPlaylistOrder.isSupported();
     var sortConfig = AppState.get(
       'playlist.sort',
-      PlayableSortConfig(field: 'position', order: SortOrder.asc),
+      PlayableSortConfig(
+        field: supportsCustomOrder ? 'position' : 'title',
+        order: SortOrder.asc,
+      ),
     )!;
 
     return Scaffold(
@@ -98,7 +103,12 @@ class _PlaylistDetailsScreen extends State<PlaylistDetailsScreen> {
                     backgroundImage: _buildBackgroundImage(playlist, playables),
                     actions: [
                       SortButton(
-                        fields: ['position', 'title', 'artist_name', 'created_at'],
+                        fields: [
+                          if (supportsCustomOrder) 'position',
+                          'title',
+                          'artist_name',
+                          'created_at'
+                        ],
                         currentField: sortConfig.field,
                         currentOrder: sortConfig.order,
                         onMenuItemSelected: (_sortConfig) {

--- a/lib/ui/widgets/playable_list_sort_button.dart
+++ b/lib/ui/widgets/playable_list_sort_button.dart
@@ -12,6 +12,7 @@ class SortButton extends StatelessWidget {
   SortOrder currentOrder;
 
   static const sortFields = {
+    'position': 'Custom order',
     'track': 'Track number',
     'disc': 'Disc number',
     'title': 'Title',

--- a/lib/utils/features.dart
+++ b/lib/utils/features.dart
@@ -8,6 +8,10 @@ enum Feature {
   // Favorite/unfavorite for albums, artists, radio stations, and
   // podcasts (the song-level "like" predates this).
   favoriteEntities,
+  // A user-defined order for a playlist's songs (pivot `position`).
+  customPlaylistOrder,
+  // A user-defined order for favorite songs (`favorites.position`).
+  customFavoritesOrder,
 }
 
 Map<Feature, String> supportedVersionMap = {
@@ -15,6 +19,8 @@ Map<Feature, String> supportedVersionMap = {
   Feature.queueStateSync: '6.11.6',
   Feature.radioStations: '7.13.0',
   Feature.favoriteEntities: '7.11.0',
+  Feature.customPlaylistOrder: '7.0.2',
+  Feature.customFavoritesOrder: '9.0.0',
 };
 
 extension FeatureExtension on Feature {

--- a/test/extensions/playable_list_test.dart
+++ b/test/extensions/playable_list_test.dart
@@ -1,0 +1,44 @@
+import 'package:app/enums.dart';
+import 'package:app/extensions/extensions.dart';
+import 'package:app/models/models.dart';
+import 'package:app/values/values.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Song a, b, c;
+
+  setUp(() {
+    a = Song.fake(title: 'A');
+    b = Song.fake(title: 'B');
+    c = Song.fake(title: 'C');
+  });
+
+  // Deliberately not alphabetical — mimics a playlist's custom order.
+  List<Playable> customOrder() => <Playable>[c, a, b];
+
+  PlayableSortConfig config(String field, SortOrder order) =>
+      PlayableSortConfig(field: field, order: order);
+
+  group('\$sort', () {
+    test('position keeps the server-provided order', () {
+      final sorted = customOrder().$sort(config('position', SortOrder.asc));
+      expect(sorted, [c, a, b]);
+    });
+
+    test('position descending reverses the server-provided order', () {
+      final sorted = customOrder().$sort(config('position', SortOrder.desc));
+      expect(sorted, [b, a, c]);
+    });
+
+    test('other fields still sort', () {
+      final sorted = customOrder().$sort(config('title', SortOrder.asc));
+      expect(sorted.map((playable) => (playable as Song).title), ['A', 'B', 'C']);
+    });
+
+    test('does not mutate the original list', () {
+      final original = customOrder();
+      original.$sort(config('title', SortOrder.asc));
+      expect(original, [c, a, b]);
+    });
+  });
+}

--- a/test/extensions/playable_list_test.dart
+++ b/test/extensions/playable_list_test.dart
@@ -5,16 +5,16 @@ import 'package:app/values/values.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  late Song a, b, c;
+  late Song songA, songB, songC;
 
   setUp(() {
-    a = Song.fake(title: 'A');
-    b = Song.fake(title: 'B');
-    c = Song.fake(title: 'C');
+    songA = Song.fake(title: 'A');
+    songB = Song.fake(title: 'B');
+    songC = Song.fake(title: 'C');
   });
 
   // Deliberately not alphabetical — mimics a playlist's custom order.
-  List<Playable> customOrder() => <Playable>[c, a, b];
+  List<Playable> customOrder() => <Playable>[songC, songA, songB];
 
   PlayableSortConfig config(String field, SortOrder order) =>
       PlayableSortConfig(field: field, order: order);
@@ -22,12 +22,12 @@ void main() {
   group('\$sort', () {
     test('position keeps the server-provided order', () {
       final sorted = customOrder().$sort(config('position', SortOrder.asc));
-      expect(sorted, [c, a, b]);
+      expect(sorted, [songC, songA, songB]);
     });
 
     test('position descending reverses the server-provided order', () {
       final sorted = customOrder().$sort(config('position', SortOrder.desc));
-      expect(sorted, [b, a, c]);
+      expect(sorted, [songB, songA, songC]);
     });
 
     test('other fields still sort', () {
@@ -38,7 +38,9 @@ void main() {
     test('does not mutate the original list', () {
       final original = customOrder();
       original.$sort(config('title', SortOrder.asc));
-      expect(original, [c, a, b]);
+      original.$sort(config('position', SortOrder.asc));
+      original.$sort(config('position', SortOrder.desc));
+      expect(original, [songC, songA, songB]);
     });
   });
 }

--- a/test/utils/features_test.dart
+++ b/test/utils/features_test.dart
@@ -48,6 +48,36 @@ void main() {
     });
   });
 
+  group('Feature.customPlaylistOrder', () {
+    test('is supported at 7.0.2 and above', () {
+      AppState.set(['app', 'apiVersion'], Version.parse('7.0.2'));
+      expect(Feature.customPlaylistOrder.isSupported(), isTrue);
+      AppState.set(['app', 'apiVersion'], Version.parse('9.0.0'));
+      expect(Feature.customPlaylistOrder.isSupported(), isTrue);
+    });
+
+    test('is not supported below 7.0.2', () {
+      AppState.set(['app', 'apiVersion'], Version.parse('7.0.1'));
+      expect(Feature.customPlaylistOrder.isSupported(), isFalse);
+    });
+  });
+
+  group('Feature.customFavoritesOrder', () {
+    test('is supported at 9.0.0 and above', () {
+      AppState.set(['app', 'apiVersion'], Version.parse('9.0.0'));
+      expect(Feature.customFavoritesOrder.isSupported(), isTrue);
+    });
+
+    test('is not supported below 9.0.0', () {
+      AppState.set(['app', 'apiVersion'], Version.parse('8.9.9'));
+      expect(Feature.customFavoritesOrder.isSupported(), isFalse);
+    });
+
+    test('is not supported when API version is not set', () {
+      expect(Feature.customFavoritesOrder.isSupported(), isFalse);
+    });
+  });
+
   group('Feature.podcasts', () {
     test('is supported when API version is 7.0.0 or above', () {
       AppState.set(['app', 'apiVersion'], Version.parse('7.0.0'));


### PR DESCRIPTION
Fixes #202.

## Problem
On mobile, playlist **and** favorites songs were always re-sorted — defaulting to Title, with only Title / Artist / Recently added available. That discarded the user-defined order the server returns:
- Playlists: `playlists/{id}/songs` → `->orderByPivot('position')` (since koel **7.0.2**)
- Favorites: `songs/favorites` → `->orderBy('favorites.position')`, with a `favorites/move` endpoint (since koel **9.0.0**)

So the app couldn't play them in their intended order, and "Recently added" sorts by the song's date rather than the add order.

## Changes
- **`$sort`**: a `'position'` field preserves the server-provided order (reversible via the sort direction) instead of comparing a field. It also returns a **new** list rather than sorting in place, so it no longer mutates the cached list.
- **Sort menu**: adds `Custom order`.
- **Playlist details** and **Favorites**: default to `Custom order` and offer it in the sort button.

## Older servers
`'position'` is a sort-mode sentinel, not a per-song field — nothing is read from the response, so the sort can't break on any server. But an older server returns a raw (non-custom) order, so the `Custom order` default and menu entry are gated behind the server version (`Feature.customPlaylistOrder` = 7.0.2, `Feature.customFavoritesOrder` = 9.0.0); older servers keep the previous Title default.

## Tests
- `playable_list_test.dart`: `Custom order` keeps the server order; descending reverses it; other fields still sort; `$sort` doesn't mutate the original.
- `features_test.dart`: version thresholds for the two new features.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Custom order” (position) option to sort menus for playlist details and favorites.
  * Playlist details and favorites now default to custom order when supported; otherwise they default to title.
* **Bug Fixes**
  * Sorting by position now preserves the server/custom order.
  * Descending position correctly reverses the custom order.
  * Sorting no longer mutates the original list.
* **Tests**
  * Added coverage for custom playlist/favorites ordering, sort direction behavior, and non-mutation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->